### PR TITLE
Start new frame cycle when new wayland client connected

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 110
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  AfterClass: true
+  SplitEmptyRecord: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+target/
+
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Akihiro Kiuchi and Taishi Eguchi
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,39 @@
+= Z Wayland
+
+Wayland clients under Z11.
+
+== Build
+
+Build & install link:https://github.com/gray-armor/z11[Z11] first
+
+Build & install ZWayland
+
+[source, console]
+....
+$ meson build
+$ ninja -C build install
+....
+
+== Run
+
+run z11 compositor first,
+
+[source, console]
+....
+$ XDG_RUNTIME_DIR=~/.xdg_z11 zazen -no-hmd
+....
+
+in another shell
+
+[source, console]
+....
+$ Z11_XDG_RUNTIME_DIR=~/.xdg_z11 XDG_RUNTIME_DIR=~/.xdg zwayland
+....
+
+in another shell
+
+[source, console]
+....
+$ XDG_RUNTIME_DIR=~/.xdg <some wayland client>
+$ XDG_RUNTIME_DIR=~/.xdg weston-flower
+....

--- a/include/zwc.h
+++ b/include/zwc.h
@@ -1,0 +1,20 @@
+#ifndef ZWC_H
+#define ZWC_H
+
+struct zwc_display;
+
+struct zwc_display* zwc_display_create(const char* name);
+
+void zwc_display_destroy(struct zwc_display* display);
+
+int zwc_display_prepare_read(struct zwc_display* display);
+
+int zwc_display_dispatch_pending(struct zwc_display* display);
+
+int zwc_display_flush(struct zwc_display* display);
+
+int zwc_display_read_events(struct zwc_display* display);
+
+int zwc_display_get_fd(struct zwc_display* display);
+
+#endif  //  ZWC_H

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,16 @@
+project(
+  'zwayland',
+  'c',
+  version : '0.0.1',
+  license : 'Apache-2.0',
+  default_options : ['warning_level=3', 'werror=true', 'buildtype=debug'],
+  meson_version : '>=0.57.0',
+)
+
+zwc_version = '0.0.0'
+
+public_inc = include_directories('include')
+
+subdir('protocol')
+subdir('zwc')
+subdir('server')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,0 +1,62 @@
+scanner = dependency('wayland-scanner')
+scanner_path = scanner.get_variable(pkgconfig : 'wayland_scanner')
+z11_xml = files('/usr/local/share/z11/z11.xml')
+z11_opengl_xml = files('/usr/local/share/z11/z11_opengl.xml')
+xdg_shell_xml = files('/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml')
+xdg_output_xml = files('/usr/share/wayland-protocols/unstable/xdg-output/xdg-output-unstable-v1.xml')
+
+z11_client_protocol_h = custom_target(
+  'z11-client-protocol',
+  output : 'z11-client-protocol.h',
+  input : z11_xml,
+  command : [scanner_path, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+z11_protocol_c = custom_target(
+  'z11-protocol',
+  output : 'z11-protocol.c',
+  input : z11_xml,
+  command : [scanner_path, 'public-code', '@INPUT@', '@OUTPUT@'],
+)
+
+z11_opengl_client_protocol_h = custom_target(
+  'z11-opengl-client-protocol',
+  output : 'z11-opengl-client-protocol.h',
+  input : z11_opengl_xml,
+  command : [scanner_path, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+z11_opengl_protocol_c = custom_target(
+  'z11-opengl-protocol',
+  output : 'z11-opengl-protocol.c',
+  input : z11_opengl_xml,
+  command : [scanner_path, 'public-code', '@INPUT@', '@OUTPUT@'],
+)
+
+xdg_shell_server_protocol_h = custom_target(
+  'xdg-shell-server-protocol',
+  output : 'xdg-shell-server-protocol.h',
+  input : xdg_shell_xml,
+  command : [scanner_path, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+
+xdg_shell_protocol_c = custom_target(
+  'xdg-shell-protocol',
+  output : 'xdg-shell-protocol.c',
+  input : xdg_shell_xml,
+  command : [scanner_path, 'code', '@INPUT@', '@OUTPUT@'],
+)
+
+xdg_output_server_protocol_h = custom_target(
+  'xdg-output-server-protocol',
+  output : 'xdg-output-server-protocol.h',
+  input : xdg_output_xml,
+  command : [scanner_path, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+
+xdg_output_protocol_c = custom_target(
+  'xdg-output-protocol',
+  output : 'xdg-output-protocol.c',
+  input : xdg_output_xml,
+  command : [scanner_path, 'code', '@INPUT@', '@OUTPUT@'],
+)

--- a/server/compositor.c
+++ b/server/compositor.c
@@ -1,0 +1,140 @@
+#include "compositor.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <wayland-server.h>
+#include <zwc.h>
+
+#include "compositor_global.h"
+#include "surface.h"
+#include "util.h"
+
+struct zwl_compositor {
+  struct zwc_display *zwc_display;
+  struct wl_listener global_flush_listener;
+  struct wl_event_source *event_source;
+};
+
+static void zwl_compositor_destroy(struct zwl_compositor *compositor);
+
+static void zwl_compositor_handle_destroy(struct wl_resource *resource)
+{
+  struct zwl_compositor *compositor;
+
+  compositor = wl_resource_get_user_data(resource);
+
+  zwl_compositor_destroy(compositor);
+}
+
+static void zwl_compositor_protocol_create_surface(struct wl_client *client, struct wl_resource *resource,
+                                                   uint32_t id)
+{
+  UNUSED(resource);
+  struct zwl_surface *surface = zwl_surface_create(client, id);
+  if (surface == NULL) fprintf(stderr, "failed to create a surface\n");
+}
+
+static void zwl_compositor_protocol_create_region(struct wl_client *client, struct wl_resource *resource,
+                                                  uint32_t id)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(id);
+  // TODO: implement
+}
+
+static const struct wl_compositor_interface zwl_compositor_interface = {
+    .create_surface = zwl_compositor_protocol_create_surface,
+    .create_region = zwl_compositor_protocol_create_region,
+};
+
+static int zwl_compositor_zwc_dispatch(int fd, uint32_t mask, void *data)
+{
+  UNUSED(fd);
+  UNUSED(mask);
+  struct zwl_compositor *compositor = data;
+
+  while (zwc_display_prepare_read(compositor->zwc_display) != 0) {
+    if (errno != EAGAIN) {
+      zwl_compositor_destroy(compositor);
+      fprintf(stderr, "Disconnected");
+      return 0;
+    };
+    zwc_display_dispatch_pending(compositor->zwc_display);
+  }
+  if (zwc_display_flush(compositor->zwc_display) == -1) {
+    zwl_compositor_destroy(compositor);
+    fprintf(stderr, "Disconnected");
+    return 0;
+  }
+  zwc_display_read_events(compositor->zwc_display);
+  zwc_display_dispatch_pending(compositor->zwc_display);
+  return 0;
+}
+
+static void zwl_compositor_global_flush_handler(struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zwl_compositor *compositor;
+
+  compositor = wl_container_of(listener, compositor, global_flush_listener);
+
+  zwc_display_flush(compositor->zwc_display);
+}
+
+struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t version, uint32_t id,
+                                             struct zwl_compositor_global *compositor_global)
+{
+  UNUSED(compositor_global);
+  struct zwl_compositor *compositor;
+  struct wl_resource *resource;
+  int fd;
+
+  compositor = zalloc(sizeof *compositor);
+  if (compositor == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  compositor->zwc_display = zwc_display_create(NULL);
+  if (compositor->zwc_display == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_compositor;
+  }
+
+  resource = wl_resource_create(client, &wl_compositor_interface, version, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_zwc_display;
+  }
+  wl_resource_set_implementation(resource, &zwl_compositor_interface, compositor,
+                                 zwl_compositor_handle_destroy);
+
+  struct wl_event_loop *loop = wl_display_get_event_loop(compositor_global->display);
+
+  fd = zwc_display_get_fd(compositor->zwc_display);
+  compositor->event_source =
+      wl_event_loop_add_fd(loop, fd, WL_EVENT_READABLE, zwl_compositor_zwc_dispatch, compositor);
+
+  compositor->global_flush_listener.notify = zwl_compositor_global_flush_handler;
+  wl_signal_add(&compositor_global->flush_signal, &compositor->global_flush_listener);
+
+  return compositor;
+
+out_zwc_display:
+  zwc_display_destroy(compositor->zwc_display);
+
+out_compositor:
+  free(compositor);
+
+out:
+  return NULL;
+}
+
+static void zwl_compositor_destroy(struct zwl_compositor *compositor)
+{
+  zwc_display_destroy(compositor->zwc_display);
+  wl_list_remove(&compositor->global_flush_listener.link);
+  wl_event_source_remove(compositor->event_source);
+  free(compositor);
+}

--- a/server/compositor.h
+++ b/server/compositor.h
@@ -1,0 +1,13 @@
+#ifndef ZWAYLAND_COMPOSITOR_H
+#define ZWAYLAND_COMPOSITOR_H
+
+#include <wayland-server.h>
+
+#include "compositor_global.h"
+
+struct zwl_compositor;
+
+struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t version, uint32_t id,
+                                             struct zwl_compositor_global *compositor_global);
+
+#endif  //  ZWAYLAND_COMPOSITOR_H

--- a/server/compositor_global.c
+++ b/server/compositor_global.c
@@ -1,0 +1,42 @@
+#include "compositor_global.h"
+
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "compositor.h"
+#include "util.h"
+
+static void zwl_compositor_global_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+{
+  struct zwl_compositor_global *compositor_global = data;
+  struct zwl_compositor *compositor;
+
+  compositor = zwl_compositor_create(client, version, id, compositor_global);
+  if (compositor == NULL) {
+    fprintf(stderr, "fail to create compositor client\n");
+  }
+}
+
+struct zwl_compositor_global *zwl_compositor_global_create(struct wl_display *display)
+{
+  struct zwl_compositor_global *compositor_global;
+  struct wl_global *global;
+
+  compositor_global = zalloc(sizeof *compositor_global);
+  if (compositor_global == NULL) goto out;
+
+  global =
+      wl_global_create(display, &wl_compositor_interface, 4, compositor_global, zwl_compositor_global_bind);
+  if (global == NULL) goto out_compositor;
+
+  compositor_global->display = display;
+  wl_signal_init(&compositor_global->flush_signal);
+
+  return compositor_global;
+
+out_compositor:
+  free(compositor_global);
+
+out:
+  return NULL;
+}

--- a/server/compositor_global.h
+++ b/server/compositor_global.h
@@ -1,0 +1,15 @@
+#ifndef ZWAYLAND_COMPOSITOR_GLOBAL_H
+#define ZWAYLAND_COMPOSITOR_GLOBAL_H
+
+#include <wayland-server.h>
+
+/* compositor */
+
+struct zwl_compositor_global {
+  struct wl_display *display;
+  struct wl_signal flush_signal;
+};
+
+struct zwl_compositor_global *zwl_compositor_global_create(struct wl_display *display);
+
+#endif  //  ZWAYLAND_COMPOSITOR_GLOBAL_H

--- a/server/main.c
+++ b/server/main.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "compositor.h"
+#include "compositor_global.h"
+#include "util.h"
+#include "xdg_wm_base_global.h"
+
+int main(int argc, char const *argv[])
+{
+  UNUSED(argc);
+  UNUSED(argv);
+  struct wl_display *display;
+  struct zwl_compositor_global *compositor;
+  struct zwl_wm_base_global *wm_base;
+  const char *socket;
+
+  display = wl_display_create();
+  UNUSED(display);
+
+  compositor = zwl_compositor_global_create(display);
+  if (compositor == NULL) {
+    fprintf(stderr, "failed to create a global compostor\n");
+    return EXIT_FAILURE;
+  }
+
+  wm_base = zwl_wm_base_global_create(display);
+  if (wm_base == NULL) {
+    fprintf(stderr, "failed to create a global wm base\n");
+    return EXIT_FAILURE;
+  }
+
+  if (wl_display_init_shm(display) == -1) {
+    fprintf(stderr, "failed to initialize shared memory");
+    return EXIT_FAILURE;
+  }
+
+  socket = wl_display_add_socket_auto(display);
+
+  if (socket == NULL) {
+    fprintf(stderr, "failed to add socket\n");
+    return EXIT_FAILURE;
+  }
+
+  while (1) {
+    wl_display_flush_clients(display);
+    wl_event_loop_dispatch(wl_display_get_event_loop(display), 0);
+    wl_signal_emit(&compositor->flush_signal, compositor);
+  }
+
+  return 0;
+}

--- a/server/meson.build
+++ b/server/meson.build
@@ -1,0 +1,27 @@
+source_files = [
+  'compositor.c',
+  'compositor_global.c',
+  'main.c',
+  'surface.c',
+  'util.c',
+  'xdg_surface.c',
+  'xdg_toplevel.c',
+  'xdg_wm_base.c',
+  'xdg_wm_base_global.c',
+  xdg_output_protocol_c,
+  xdg_output_server_protocol_h,
+  xdg_shell_protocol_c,
+  xdg_shell_server_protocol_h,
+]
+
+dependencies = [
+  dependency('wayland-server'),
+  libzwc_dep,
+]
+
+executable(
+  meson.project_name(),
+  source_files,
+  install : true,
+  dependencies : dependencies,
+)

--- a/server/surface.c
+++ b/server/surface.c
@@ -1,0 +1,165 @@
+#include "surface.h"
+
+#include <wayland-server.h>
+
+#include "util.h"
+
+struct zwl_surface {
+  struct wl_signal destroy_signal;
+};
+
+static void zwl_surface_destroy(struct zwl_surface *surface);
+
+static void zwl_surface_handle_destroy(struct wl_resource *resource)
+{
+  struct zwl_surface *surface;
+
+  surface = wl_resource_get_user_data(resource);
+
+  zwl_surface_destroy(surface);
+}
+
+static void zwl_surface_protocol_destory(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+static void zwl_surface_protocol_attach(struct wl_client *client, struct wl_resource *resource,
+                                        struct wl_resource *buffer, int32_t x, int32_t y)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(buffer);
+  UNUSED(x);
+  UNUSED(y);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_damage(struct wl_client *client, struct wl_resource *resource, int32_t x,
+                                        int32_t y, int32_t width, int32_t height)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(x);
+  UNUSED(y);
+  UNUSED(width);
+  UNUSED(height);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_frame(struct wl_client *client, struct wl_resource *resource,
+                                       uint32_t callback)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(callback);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_set_opaque_region(struct wl_client *client, struct wl_resource *resource,
+                                                   struct wl_resource *region)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(region);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_set_input_region(struct wl_client *client, struct wl_resource *resource,
+                                                  struct wl_resource *region)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(region);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_commit(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_set_buffer_transform(struct wl_client *client, struct wl_resource *resource,
+                                                      int32_t transform)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(transform);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_set_buffer_scale(struct wl_client *client, struct wl_resource *resource,
+                                                  int32_t scale)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(scale);
+  // TODO: implement
+}
+
+static void zwl_surface_protocol_damage_buffer(struct wl_client *client, struct wl_resource *resource,
+                                               int32_t x, int32_t y, int32_t width, int32_t height)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(x);
+  UNUSED(y);
+  UNUSED(width);
+  UNUSED(height);
+  // TODO: implement
+}
+
+static const struct wl_surface_interface zwl_surface_interface = {
+    .destroy = zwl_surface_protocol_destory,
+    .attach = zwl_surface_protocol_attach,
+    .damage = zwl_surface_protocol_damage,
+    .frame = zwl_surface_protocol_frame,
+    .set_opaque_region = zwl_surface_protocol_set_opaque_region,
+    .set_input_region = zwl_surface_protocol_set_input_region,
+    .commit = zwl_surface_protocol_commit,
+    .set_buffer_transform = zwl_surface_protocol_set_buffer_transform,
+    .set_buffer_scale = zwl_surface_protocol_set_buffer_scale,
+    .damage_buffer = zwl_surface_protocol_damage_buffer,
+};
+
+struct zwl_surface *zwl_surface_create(struct wl_client *client, uint32_t id)
+{
+  struct zwl_surface *surface;
+  struct wl_resource *resource;
+
+  surface = zalloc(sizeof *surface);
+  if (surface == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  resource = wl_resource_create(client, &wl_surface_interface, 4, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_surface;
+  }
+  wl_resource_set_implementation(resource, &zwl_surface_interface, surface, zwl_surface_handle_destroy);
+
+  wl_signal_init(&surface->destroy_signal);
+
+  return surface;
+
+out_surface:
+  free(surface);
+
+out:
+  return NULL;
+}
+
+static void zwl_surface_destroy(struct zwl_surface *surface)
+{
+  wl_signal_emit(&surface->destroy_signal, surface);
+  free(surface);
+}
+
+struct wl_signal *zwl_surface_get_destroy_signal(struct zwl_surface *surface)
+{
+  return &surface->destroy_signal;
+}

--- a/server/surface.h
+++ b/server/surface.h
@@ -1,0 +1,12 @@
+#ifndef ZWAYLAND_SURFACE_H
+#define ZWAYLAND_SURFACE_H
+
+#include <wayland-server.h>
+
+struct zwl_surface;
+
+struct zwl_surface *zwl_surface_create(struct wl_client *client, uint32_t id);
+
+struct wl_signal *zwl_surface_get_destroy_signal(struct zwl_surface *surface);
+
+#endif  // ZWAYLAND_SURFACE_H

--- a/server/util.c
+++ b/server/util.c
@@ -1,0 +1,37 @@
+#include "util.h"
+
+#include <stdio.h>
+#include <wayland-server.h>
+
+static void zwl_week_pointer_handle_destroy_signal_handler(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zwl_week_ref* ref;
+
+  ref = wl_container_of(listener, ref, destroy_listener);
+  if (ref->destroy_func) ref->destroy_func(ref->data);
+
+  wl_list_remove(&ref->destroy_listener.link);
+  wl_list_init(&ref->destroy_listener.link);
+  ref->data = NULL;
+  ref->destroy_func = NULL;
+}
+
+void zwl_week_ref_init(struct zwl_week_ref* ref)
+{
+  wl_list_init(&ref->destroy_listener.link);
+  ref->destroy_listener.notify = zwl_week_pointer_handle_destroy_signal_handler;
+  ref->data = NULL;
+  ref->destroy_func = NULL;
+}
+
+void zwl_week_ref_destroy(struct zwl_week_ref* ref) { wl_list_remove(&ref->destroy_listener.link); }
+
+void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+                           zwl_week_ref_destroy_func_t on_destroy)
+{
+  wl_list_remove(&ref->destroy_listener.link);
+  wl_signal_add(destroy_signal, &ref->destroy_listener);
+  ref->data = data;
+  ref->destroy_func = on_destroy;
+}

--- a/server/util.h
+++ b/server/util.h
@@ -1,0 +1,29 @@
+#ifndef ZWAYLAND_UTIL_H
+#define ZWAYLAND_UTIL_H
+
+#include <stdlib.h>
+#include <wayland-server.h>
+#define UNUSED(x) ((void)x)
+
+static inline void* zalloc(size_t size) { return calloc(1, size); }
+
+/* week ref */
+
+struct zwl_week_ref;
+
+typedef void (*zwl_week_ref_destroy_func_t)(struct zwl_week_ref* ref);
+
+struct zwl_week_ref {
+  void* data;  // NULLABLE
+  struct wl_listener destroy_listener;
+  zwl_week_ref_destroy_func_t destroy_func;
+};
+
+void zwl_week_ref_init(struct zwl_week_ref* week_ref);
+
+void zwl_week_ref_destroy(struct zwl_week_ref* ref);
+
+void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+                           zwl_week_ref_destroy_func_t on_destroy);
+
+#endif  // ZWAYLAND_UTIL_H

--- a/server/xdg_surface.c
+++ b/server/xdg_surface.c
@@ -1,0 +1,145 @@
+#include "xdg_surface.h"
+
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "surface.h"
+#include "util.h"
+#include "xdg-shell-server-protocol.h"
+#include "xdg_surface.h"
+#include "xdg_toplevel.h"
+
+struct zwl_xdg_surface {
+  struct wl_resource* resource;
+  struct wl_signal destroy_signal;
+  struct zwl_surface* surface;
+  struct wl_listener surface_destroy_listener;
+};
+
+static void zwl_xdg_surface_destroy(struct zwl_xdg_surface* xdg_surface);
+
+static void zwl_xdg_surface_handle_destroy(struct wl_resource* resource)
+{
+  struct zwl_xdg_surface* xdg_surface;
+
+  xdg_surface = wl_resource_get_user_data(resource);
+
+  zwl_xdg_surface_destroy(xdg_surface);
+}
+
+static void zwl_xdg_surface_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static void zwl_xdg_surface_protocol_get_toplevel(struct wl_client* client, struct wl_resource* resource,
+                                                  uint32_t id)
+{
+  struct zwl_xdg_surface* xdg_surface = wl_resource_get_user_data(resource);
+  struct zwl_xdg_toplevel* xdg_toplevel;
+
+  xdg_toplevel = zwl_xdg_toplevel_create(client, id, xdg_surface);
+  if (xdg_toplevel == NULL) {
+    fprintf(stderr, "failed to create a xdg toplevel surface\n");
+  }
+}
+
+static void zwl_xdg_surface_protocol_get_popup(struct wl_client* client, struct wl_resource* resource,
+                                               uint32_t id, struct wl_resource* parent,
+                                               struct wl_resource* positioner)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(id);
+  UNUSED(parent);
+  UNUSED(positioner);
+  // TODO: implement
+}
+
+static void zwl_xdg_surface_protocol_set_window_geometry(struct wl_client* client,
+                                                         struct wl_resource* resource, int32_t x, int32_t y,
+                                                         int32_t width, int32_t height)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(x);
+  UNUSED(y);
+  UNUSED(width);
+  UNUSED(height);
+  // TODO: implement
+}
+
+static void zwl_xdg_surface_protocol_ack_configure(struct wl_client* client, struct wl_resource* resource,
+                                                   uint32_t serial)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(serial);
+  // TODO: implement
+}
+
+static const struct xdg_surface_interface zwl_xdg_surface_interface = {
+    .destroy = zwl_xdg_surface_protocol_destroy,
+    .get_toplevel = zwl_xdg_surface_protocol_get_toplevel,
+    .get_popup = zwl_xdg_surface_protocol_get_popup,
+    .set_window_geometry = zwl_xdg_surface_protocol_set_window_geometry,
+    .ack_configure = zwl_xdg_surface_protocol_ack_configure,
+};
+
+static void zwl_xdg_surface_surface_destroy_signal_handler(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zwl_xdg_surface* xdg_surface = wl_container_of(listener, xdg_surface, surface_destroy_listener);
+  wl_resource_destroy(xdg_surface->resource);
+}
+
+struct zwl_xdg_surface* zwl_xdg_surface_create(struct wl_client* client, uint32_t id,
+                                               struct zwl_surface* surface)
+{
+  struct zwl_xdg_surface* xdg_surface;
+  struct wl_resource* resource;
+  struct wl_signal* surface_destroy_signal;
+
+  xdg_surface = zalloc(sizeof *xdg_surface);
+  if (xdg_surface == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  resource = wl_resource_create(client, &xdg_surface_interface, 3, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_xdg_surface;
+  }
+  wl_resource_set_implementation(resource, &zwl_xdg_surface_interface, xdg_surface,
+                                 zwl_xdg_surface_handle_destroy);
+
+  xdg_surface->resource = resource;
+  wl_signal_init(&xdg_surface->destroy_signal);
+
+  xdg_surface->surface = surface;
+  xdg_surface->surface_destroy_listener.notify = zwl_xdg_surface_surface_destroy_signal_handler;
+  surface_destroy_signal = zwl_surface_get_destroy_signal(surface);
+  wl_signal_add(surface_destroy_signal, &xdg_surface->surface_destroy_listener);
+
+  return xdg_surface;
+
+out_xdg_surface:
+  free(xdg_surface);
+
+out:
+  return NULL;
+}
+
+static void zwl_xdg_surface_destroy(struct zwl_xdg_surface* xdg_surface)
+{
+  wl_signal_emit(&xdg_surface->destroy_signal, xdg_surface);
+  wl_list_remove(&xdg_surface->surface_destroy_listener.link);
+  free(xdg_surface);
+}
+
+struct wl_signal* zwl_xdg_surface_get_destroy_signal(struct zwl_xdg_surface* xdg_surface)
+{
+  return &xdg_surface->destroy_signal;
+}

--- a/server/xdg_surface.h
+++ b/server/xdg_surface.h
@@ -1,0 +1,15 @@
+#ifndef ZWAYLAND_XDG_SURFACE_H
+#define ZWAYLAND_XDG_SURFACE_H
+
+#include <wayland-server.h>
+
+#include "surface.h"
+
+struct zwl_xdg_surface;
+
+struct zwl_xdg_surface *zwl_xdg_surface_create(struct wl_client *client, uint32_t id,
+                                               struct zwl_surface *surface);
+
+struct wl_signal *zwl_xdg_surface_get_destroy_signal(struct zwl_xdg_surface *xdg_surface);
+
+#endif  //  ZWAYLAND_XDG_SURFACE_H

--- a/server/xdg_toplevel.c
+++ b/server/xdg_toplevel.c
@@ -1,0 +1,224 @@
+#include "xdg_toplevel.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <wayland-server.h>
+
+#include "util.h"
+#include "xdg-shell-server-protocol.h"
+#include "xdg_surface.h"
+
+struct zwl_xdg_toplevel {
+  struct wl_resource *resource;
+  struct zwl_xdg_surface *xdg_surface;
+  struct wl_listener xdg_surface_destroy_listener;
+  char *title;
+};
+
+static void zwl_xdg_toplevel_destroy(struct zwl_xdg_toplevel *xdg_toplevel);
+
+static void zwl_xdg_toplevel_handle_destroy(struct wl_resource *resource)
+{
+  struct zwl_xdg_toplevel *xdg_toplevel;
+
+  xdg_toplevel = wl_resource_get_user_data(resource);
+
+  zwl_xdg_toplevel_destroy(xdg_toplevel);
+}
+
+static void zwl_xdg_toplevel_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static void zwl_xdg_toplevel_protocol_set_parent(struct wl_client *client, struct wl_resource *resource,
+                                                 struct wl_resource *parent)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(parent);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_title(struct wl_client *client, struct wl_resource *resource,
+                                                const char *title)
+{
+  UNUSED(client);
+  char *tmp, *old;
+  struct zwl_xdg_toplevel *xdg_toplevel = wl_resource_get_user_data(resource);
+  tmp = strdup(title);
+  if (tmp == NULL) return;
+  old = xdg_toplevel->title;
+  xdg_toplevel->title = tmp;
+  free(old);
+}
+
+static void zwl_xdg_toplevel_protocol_set_app_id(struct wl_client *client, struct wl_resource *resource,
+                                                 const char *app_id)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(app_id);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_show_window_menu(struct wl_client *client, struct wl_resource *resource,
+                                                       struct wl_resource *seat, uint32_t serial, int32_t x,
+                                                       int32_t y)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(seat);
+  UNUSED(serial);
+  UNUSED(x);
+  UNUSED(y);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_move(struct wl_client *client, struct wl_resource *resource,
+                                           struct wl_resource *seat, uint32_t serial)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(seat);
+  UNUSED(serial);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_resize(struct wl_client *client, struct wl_resource *resource,
+                                             struct wl_resource *seat, uint32_t serial, uint32_t edges)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(seat);
+  UNUSED(serial);
+  UNUSED(edges);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_max_size(struct wl_client *client, struct wl_resource *resource,
+                                                   int32_t width, int32_t height)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(width);
+  UNUSED(height);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_min_size(struct wl_client *client, struct wl_resource *resource,
+                                                   int32_t width, int32_t height)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(width);
+  UNUSED(height);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_maximized(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_unset_maximized(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_fullscreen(struct wl_client *client, struct wl_resource *resource,
+                                                     struct wl_resource *output)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(output);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  // TODO: implement
+}
+
+static void zwl_xdg_toplevel_protocol_set_minimized(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  // TODO: implement
+}
+
+static const struct xdg_toplevel_interface zwl_xdg_toplevel_interface = {
+    .destroy = zwl_xdg_toplevel_protocol_destroy,
+    .set_parent = zwl_xdg_toplevel_protocol_set_parent,
+    .set_title = zwl_xdg_toplevel_protocol_set_title,
+    .set_app_id = zwl_xdg_toplevel_protocol_set_app_id,
+    .show_window_menu = zwl_xdg_toplevel_protocol_show_window_menu,
+    .move = zwl_xdg_toplevel_protocol_move,
+    .resize = zwl_xdg_toplevel_protocol_resize,
+    .set_max_size = zwl_xdg_toplevel_protocol_set_max_size,
+    .set_min_size = zwl_xdg_toplevel_protocol_set_min_size,
+    .set_maximized = zwl_xdg_toplevel_protocol_set_maximized,
+    .unset_maximized = zwl_xdg_toplevel_protocol_unset_maximized,
+    .set_fullscreen = zwl_xdg_toplevel_protocol_set_fullscreen,
+    .unset_fullscreen = zwl_xdg_toplevel_protocol_unset_fullscreen,
+    .set_minimized = zwl_xdg_toplevel_protocol_set_minimized,
+};
+
+static void zwl_xdg_toplevel_xdg_surface_destroy_signal_handler(struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zwl_xdg_toplevel *xdg_toplevel =
+      wl_container_of(listener, xdg_toplevel, xdg_surface_destroy_listener);
+  wl_resource_destroy(xdg_toplevel->resource);
+}
+
+struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint32_t id,
+                                                 struct zwl_xdg_surface *xdg_surface)
+{
+  struct zwl_xdg_toplevel *xdg_toplevel;
+  struct wl_resource *resource;
+  struct wl_signal *xdg_surface_destroy_signal;
+
+  xdg_toplevel = zalloc(sizeof *xdg_toplevel);
+  if (xdg_toplevel == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  resource = wl_resource_create(client, &xdg_toplevel_interface, 3, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_xdg_toplevel;
+  }
+  wl_resource_set_implementation(resource, &zwl_xdg_toplevel_interface, xdg_toplevel,
+                                 zwl_xdg_toplevel_handle_destroy);
+
+  xdg_toplevel->resource = resource;
+  xdg_toplevel->title = strdup("");
+
+  xdg_toplevel->xdg_surface = xdg_surface;
+  xdg_toplevel->xdg_surface_destroy_listener.notify = zwl_xdg_toplevel_xdg_surface_destroy_signal_handler;
+  xdg_surface_destroy_signal = zwl_xdg_surface_get_destroy_signal(xdg_surface);
+  wl_signal_add(xdg_surface_destroy_signal, &xdg_toplevel->xdg_surface_destroy_listener);
+
+  return xdg_toplevel;
+
+out_xdg_toplevel:
+  free(xdg_toplevel);
+
+out:
+  return NULL;
+}
+
+static void zwl_xdg_toplevel_destroy(struct zwl_xdg_toplevel *xdg_toplevel)
+{
+  wl_list_remove(&xdg_toplevel->xdg_surface_destroy_listener.link);
+  free(xdg_toplevel);
+}

--- a/server/xdg_toplevel.h
+++ b/server/xdg_toplevel.h
@@ -1,0 +1,13 @@
+#ifndef ZWAYLAND_XDG_TOPLEVEL_H
+#define ZWAYLAND_XDG_TOPLEVEL_H
+
+#include <wayland-server.h>
+
+#include "xdg_surface.h"
+
+struct zwl_xdg_toplevel;
+
+struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint32_t id,
+                                                 struct zwl_xdg_surface *xdg_surface);
+
+#endif  //  ZWAYLAND_XDG_TOPLEVEL_H

--- a/server/xdg_wm_base.c
+++ b/server/xdg_wm_base.c
@@ -1,0 +1,100 @@
+#include "xdg_wm_base.h"
+
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "surface.h"
+#include "util.h"
+#include "xdg-shell-server-protocol.h"
+#include "xdg_surface.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zwl_wm_base {};
+#pragma GCC diagnostic pop
+
+static void zwl_wm_base_destroy(struct zwl_wm_base *wm_base);
+
+static void zwl_wm_base_handle_destroy(struct wl_resource *resource)
+{
+  struct zwl_wm_base *wm_base;
+
+  wm_base = wl_resource_get_user_data(resource);
+
+  zwl_wm_base_destroy(wm_base);
+}
+
+static void zwl_wm_base_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static void zwl_wm_base_protocol_create_positioner(struct wl_client *client, struct wl_resource *resource,
+                                                   uint32_t id)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(id);
+  // TODO: implementation
+}
+
+static void zwl_wm_base_protocol_get_xdg_surface(struct wl_client *client, struct wl_resource *resource,
+                                                 uint32_t id, struct wl_resource *surface_resource)
+{
+  UNUSED(resource);
+  struct zwl_xdg_surface *xdg_furface;
+  struct zwl_surface *surface;
+
+  surface = wl_resource_get_user_data(surface_resource);
+
+  xdg_furface = zwl_xdg_surface_create(client, id, surface);
+  if (xdg_furface == NULL) {
+    fprintf(stderr, "failed to create a xdg surface\n");
+  }
+}
+
+static void zwl_wm_base_protocol_pong(struct wl_client *client, struct wl_resource *resource, uint32_t serial)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(serial);
+  // TODO: implementation
+}
+
+static const struct xdg_wm_base_interface zwl_wm_base_interface = {
+    .destroy = zwl_wm_base_protocol_destroy,
+    .create_positioner = zwl_wm_base_protocol_create_positioner,
+    .get_xdg_surface = zwl_wm_base_protocol_get_xdg_surface,
+    .pong = zwl_wm_base_protocol_pong,
+};
+
+struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client, uint32_t version, uint32_t id)
+{
+  UNUSED(version);
+  struct zwl_wm_base *wm_base;
+  struct wl_resource *resource;
+
+  wm_base = zalloc(sizeof *wm_base);
+  if (wm_base == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  resource = wl_resource_create(client, &xdg_wm_base_interface, 3, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_wm_base;
+  }
+  wl_resource_set_implementation(resource, &zwl_wm_base_interface, wm_base, zwl_wm_base_handle_destroy);
+
+  return wm_base;
+
+out_wm_base:
+  free(wm_base);
+
+out:
+  return NULL;
+}
+
+static void zwl_wm_base_destroy(struct zwl_wm_base *wm_base) { free(wm_base); }

--- a/server/xdg_wm_base.h
+++ b/server/xdg_wm_base.h
@@ -1,0 +1,10 @@
+#ifndef ZWAYLAND_XDG_WM_BASE
+#define ZWAYLAND_XDG_WM_BASE
+
+#include <wayland-server.h>
+
+struct zwl_wm_base;
+
+struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client, uint32_t version, uint32_t id);
+
+#endif  //  ZWAYLAND_XDG_WM_BASE

--- a/server/xdg_wm_base_global.c
+++ b/server/xdg_wm_base_global.c
@@ -1,0 +1,44 @@
+#include "xdg_wm_base_global.h"
+
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "util.h"
+#include "xdg-shell-server-protocol.h"
+#include "xdg_wm_base.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zwl_wm_base_global {};
+#pragma GCC diagnostic pop
+
+static void zwl_wm_base_global_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+{
+  UNUSED(data);
+  struct zwl_wm_base *wm_base;
+
+  wm_base = zwl_wm_base_create(client, version, id);
+  if (wm_base == NULL) {
+    fprintf(stderr, "failed to create a wm base");
+  }
+}
+
+struct zwl_wm_base_global *zwl_wm_base_global_create(struct wl_display *display)
+{
+  struct zwl_wm_base_global *wm_base_global;
+  struct wl_global *global;
+
+  wm_base_global = zalloc(sizeof *wm_base_global);
+  if (wm_base_global == NULL) goto out;
+
+  global = wl_global_create(display, &xdg_wm_base_interface, 3, wm_base_global, zwl_wm_base_global_bind);
+  if (global == NULL) goto out_wm_base;
+
+  return wm_base_global;
+
+out_wm_base:
+  free(wm_base_global);
+
+out:
+  return NULL;
+}

--- a/server/xdg_wm_base_global.h
+++ b/server/xdg_wm_base_global.h
@@ -1,0 +1,10 @@
+#ifndef ZWAYLAND_XDG_WM_BASE_GLOBAL_H
+#define ZWAYLAND_XDG_WM_BASE_GLOBAL_H
+
+#include <wayland-server.h>
+
+struct zwl_wm_base_global;
+
+struct zwl_wm_base_global *zwl_wm_base_global_create(struct wl_display *display);
+
+#endif  //  ZWAYLAND_XDG_WM_BASE_GLOBAL_H

--- a/zwc/meson.build
+++ b/zwc/meson.build
@@ -1,0 +1,29 @@
+dep_libzwc = [
+  dependency('wayland-client'),
+]
+
+srcs_libzwc = files([
+  'zwc_display.c',
+  'zwc_global.c',
+  'zwc_os.c',
+]) + [
+  z11_protocol_c,
+  z11_client_protocol_h,
+  z11_opengl_protocol_c,
+  z11_opengl_client_protocol_h,
+]
+
+lib_zwc = static_library(
+  'zwc',
+  srcs_libzwc,
+  include_directories : public_inc,
+  install : false,
+  version : zwc_version,
+  dependencies : dep_libzwc,
+)
+
+libzwc_dep = declare_dependency(
+  link_with : lib_zwc,
+  include_directories : public_inc,
+  dependencies : dep_libzwc,
+)

--- a/zwc/zwc_display.c
+++ b/zwc/zwc_display.c
@@ -1,0 +1,171 @@
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <zwc.h>
+
+#include "zwc_global.h"
+#include "zwc_os.h"
+
+struct zwc_display {
+  struct wl_display* wl_display;
+  struct zwc_global* global;
+  int fd;
+  struct z11_virtual_object* virtual_object;
+};
+
+static int connect_to_socket(const char* name)
+{
+  struct sockaddr_un addr;
+  socklen_t size;
+  const char* runtime_dir;
+  int name_size, fd;
+  bool path_is_absolute;
+
+  if (name == NULL) name = getenv("Z11_WAYLAND_DISPLAY");
+  if (name == NULL) name = "wayland-0";
+
+  path_is_absolute = name[0] == '/';
+
+  runtime_dir = getenv("Z11_XDG_RUNTIME_DIR");
+  if (!runtime_dir && !path_is_absolute) {
+    fprintf(stderr, "zwc error: Z11_XDG_RUNTIME_DIR not set in the environment.\n");
+    return -1;
+  }
+
+  fd = zwc_os_socket_cloexec(PF_LOCAL, SOCK_STREAM, 0);
+  if (fd < 0) return -1;
+
+  memset(&addr, 0, sizeof addr);
+  addr.sun_family = AF_LOCAL;
+  if (!path_is_absolute) {
+    name_size = snprintf(addr.sun_path, sizeof addr.sun_path, "%s/%s", runtime_dir, name) + 1;
+  } else {
+    /* absolute path */
+    name_size = snprintf(addr.sun_path, sizeof addr.sun_path, "%s", name) + 1;
+  }
+
+  assert(name_size > 0);
+  if (name_size > (int)sizeof addr.sun_path) {
+    if (!path_is_absolute) {
+      fprintf(stderr,
+              "zwc error: socket path \"%s/%s\" plus null terminator"
+              " exceeds %i bytes\n",
+              runtime_dir, name, (int)sizeof(addr.sun_path));
+    } else {
+      fprintf(stderr,
+              "zwc error: socket path \"%s\" plus null terminator"
+              " exceeds %i bytes\n",
+              name, (int)sizeof(addr.sun_path));
+    }
+    close(fd);
+    /* to prevent programs reporting
+     * "failed to add socket: Success" */
+    errno = ENAMETOOLONG;
+    return -1;
+  };
+
+  size = offsetof(struct sockaddr_un, sun_path) + name_size;
+
+  if (connect(fd, (struct sockaddr*)&addr, size) < 0) {
+    close(fd);
+    return -1;
+  }
+
+  return fd;
+}
+
+static void callback_done(void* data, struct wl_callback* callback, uint32_t callback_data);
+
+static const struct wl_callback_listener zwc_callback_listener = {
+    .done = callback_done,
+};
+
+static void callback_done(void* data, struct wl_callback* callback, uint32_t callback_data)
+{
+  (void)callback_data;
+  struct zwc_display* zwc_display = data;
+  struct wl_callback* cb;
+  wl_callback_destroy(callback);
+  cb = z11_virtual_object_frame(zwc_display->virtual_object);
+  wl_callback_add_listener(cb, &zwc_callback_listener, zwc_display);
+  z11_virtual_object_commit(zwc_display->virtual_object);
+}
+
+struct zwc_display* zwc_display_create(const char* name)
+{
+  struct zwc_display* zwc_display;
+  struct z11_virtual_object* virtual_object;
+  struct wl_callback* cb;
+  int fd = connect_to_socket(name);
+  if (fd < 0) goto fail;
+
+  zwc_display = calloc(1, sizeof *zwc_display);
+  if (zwc_display == NULL) goto fail;
+
+  zwc_display->wl_display = wl_display_connect_to_fd(fd);
+  if (zwc_display->wl_display == NULL) {
+    fprintf(stderr, "zwc error: can't connect to display\n");
+    goto out_zwc_display;
+  }
+
+  zwc_display->global = zwc_global_create(zwc_display->wl_display);
+  if (zwc_display->global == NULL) {
+    goto out_wl_display;
+  }
+
+  zwc_display->fd = fd;
+
+  virtual_object = z11_compositor_create_virtual_object(zwc_display->global->compositor);
+
+  zwc_display->virtual_object = virtual_object;
+
+  cb = z11_virtual_object_frame(virtual_object);
+  wl_callback_add_listener(cb, &zwc_callback_listener, zwc_display);
+  z11_virtual_object_commit(virtual_object);
+  wl_display_flush(zwc_display->wl_display);
+
+  return zwc_display;
+
+out_wl_display:
+  wl_display_disconnect(zwc_display->wl_display);
+
+out_zwc_display:
+  free(zwc_display);
+
+fail:
+  return NULL;
+}
+
+void zwc_display_destroy(struct zwc_display* zwc_display)
+{
+  zwc_global_destroy(zwc_display->global);
+  wl_display_disconnect(zwc_display->wl_display);
+  free(zwc_display);
+}
+
+int zwc_display_prepare_read(struct zwc_display* display)
+{
+  return wl_display_prepare_read(display->wl_display);
+}
+
+int zwc_display_dispatch_pending(struct zwc_display* display)
+{
+  return wl_display_dispatch_pending(display->wl_display);
+}
+
+int zwc_display_flush(struct zwc_display* display) { return wl_display_flush(display->wl_display); }
+
+int zwc_display_read_events(struct zwc_display* display)
+{
+  return wl_display_read_events(display->wl_display);
+}
+
+int zwc_display_get_fd(struct zwc_display* display) { return display->fd; }

--- a/zwc/zwc_global.c
+++ b/zwc/zwc_global.c
@@ -1,0 +1,105 @@
+#define _GNU_SOURCE 1
+
+#include "zwc_global.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "z11-client-protocol.h"
+#include "z11-opengl-client-protocol.h"
+
+void shm_format(void *data, struct wl_shm *shm, uint32_t format)
+{
+  (void)data;
+  (void)shm;
+  (void)format;
+  // TODO: handle this if needed
+}
+
+struct wl_shm_listener shm_listener = {
+    shm_format,
+};
+
+static void global_registry_handler(void *data, struct wl_registry *registry, uint32_t id,
+                                    const char *interface, uint32_t version)
+{
+  struct zwc_global *global = data;
+
+  if (strcmp(interface, "z11_compositor") == 0) {
+    global->compositor = wl_registry_bind(registry, id, &z11_compositor_interface, version);
+  } else if (strcmp(interface, "wl_shm") == 0) {
+    global->shm = wl_registry_bind(registry, id, &wl_shm_interface, version);
+    wl_shm_add_listener(global->shm, &shm_listener, NULL);
+  } else if (strcmp(interface, "z11_opengl") == 0) {
+    global->gl = wl_registry_bind(registry, id, &z11_opengl_interface, version);
+  } else if (strcmp(interface, "z11_opengl_render_component_manager") == 0) {
+    global->render_component_manager =
+        wl_registry_bind(registry, id, &z11_opengl_render_component_manager_interface, version);
+  }
+}
+
+static void global_registry_remover(void *data, struct wl_registry *registry, uint32_t id)
+{
+  (void)data;
+  (void)registry;
+  (void)id;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    global_registry_handler,
+    global_registry_remover,
+};
+
+struct zwc_global *zwc_global_create(struct wl_display *display)
+{
+  struct zwc_global *global;
+  struct wl_registry *registry;
+
+  global = malloc(sizeof *global);
+  if (global == NULL) goto out;
+
+  global->compositor = NULL;
+  global->shm = NULL;
+  global->gl = NULL;
+  global->render_component_manager = NULL;
+
+  registry = wl_display_get_registry(display);
+  if (registry == NULL) goto out_global;
+
+  global->registry = registry;
+
+  wl_registry_add_listener(registry, &registry_listener, global);
+
+  wl_display_roundtrip(display);
+  wl_display_dispatch(display);
+
+  if (!(global->compositor && global->gl && global->shm && global->render_component_manager)) {
+    if (global->compositor != NULL) z11_compositor_destroy(global->compositor);
+    if (global->gl != NULL) z11_opengl_destroy(global->gl);
+    if (global->shm != NULL) wl_shm_destroy(global->shm);
+    if (global->render_component_manager != NULL)
+      z11_opengl_render_component_manager_destroy(global->render_component_manager);
+    goto out_registry;
+  }
+
+  return global;
+
+out_registry:
+  wl_registry_destroy(registry);
+
+out_global:
+  free(global);
+
+out:
+  return NULL;
+}
+
+void zwc_global_destroy(struct zwc_global *global)
+{
+  z11_compositor_destroy(global->compositor);
+  z11_opengl_destroy(global->gl);
+  wl_shm_destroy(global->shm);
+  z11_opengl_render_component_manager_destroy(global->render_component_manager);
+  wl_registry_destroy(global->registry);
+  free(global);
+}

--- a/zwc/zwc_global.h
+++ b/zwc/zwc_global.h
@@ -1,0 +1,18 @@
+#ifndef ZWC_GLOBAL_H
+#define ZWC_GLOBAL_H
+
+#include "z11-client-protocol.h"
+
+struct zwc_global {
+  struct wl_registry *registry;
+  struct z11_compositor *compositor;
+  struct wl_shm *shm;
+  struct z11_opengl *gl;
+  struct z11_opengl_render_component_manager *render_component_manager;
+};
+
+struct zwc_global *zwc_global_create(struct wl_display *display);
+
+void zwc_global_destroy(struct zwc_global *global);
+
+#endif  //  ZWC_GLOBAL_H

--- a/zwc/zwc_os.c
+++ b/zwc/zwc_os.c
@@ -1,0 +1,36 @@
+#include "zwc_os.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int set_cloexec_or_close(int fd)
+{
+  long flags;
+
+  if (fd == -1) return -1;
+
+  flags = fcntl(fd, F_GETFD);
+  if (flags == -1) goto err;
+
+  if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) goto err;
+
+  return fd;
+
+err:
+  close(fd);
+  return -1;
+}
+
+int zwc_os_socket_cloexec(int domain, int type, int protocol)
+{
+  int fd;
+
+  fd = socket(domain, type | SOCK_CLOEXEC, protocol);
+  if (fd >= 0) return fd;
+  if (errno != EINVAL) return -1;
+
+  fd = socket(domain, type, protocol);
+  return set_cloexec_or_close(fd);
+}

--- a/zwc/zwc_os.h
+++ b/zwc/zwc_os.h
@@ -1,0 +1,6 @@
+#ifndef ZWC_OS_H
+#define ZWC_OS_H
+
+int zwc_os_socket_cloexec(int domain, int type, int protocol);
+
+#endif  //  ZWC_OS_H


### PR DESCRIPTION
Waylandクライアントから接続があった時に、Z Compositorに空のVirtual Objectを作成して、
からのcommit & frameのサイクルを回すようにした。

waylandクライアント から / へ の request / event の処理と Zcompositor から / へ の event / request を処理する基盤をまずとりあえず作ったということになります。