### PR TITLE
Change column limit of clang formatter to 80

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle: Google
 IndentWidth: 2
-ColumnLimit: 110
+ColumnLimit: 80
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterFunction: true

--- a/server/callback.c
+++ b/server/callback.c
@@ -34,7 +34,8 @@ struct zwl_callback* zwl_callback_create(struct wl_client* client, uint32_t id)
 
   callback->resource = resource;
 
-  wl_resource_set_implementation(resource, NULL, callback, zwl_callback_handle_destroy);
+  wl_resource_set_implementation(resource, NULL, callback,
+                                 zwl_callback_handle_destroy);
 
   return callback;
 
@@ -45,4 +46,7 @@ out:
   return NULL;
 }
 
-static void zwl_callback_destroy(struct zwl_callback* callback) { free(callback); }
+static void zwl_callback_destroy(struct zwl_callback* callback)
+{
+  free(callback);
+}

--- a/server/compositor.c
+++ b/server/compositor.c
@@ -23,7 +23,8 @@ static void zwl_compositor_handle_destroy(struct wl_resource *resource)
   zwl_compositor_destroy(compositor);
 }
 
-static void zwl_compositor_protocol_create_surface(struct wl_client *client, struct wl_resource *resource,
+static void zwl_compositor_protocol_create_surface(struct wl_client *client,
+                                                   struct wl_resource *resource,
                                                    uint32_t id)
 {
   struct zwl_compositor *compositor;
@@ -35,7 +36,8 @@ static void zwl_compositor_protocol_create_surface(struct wl_client *client, str
   if (surface == NULL) fprintf(stderr, "failed to create a surface\n");
 }
 
-static void zwl_compositor_protocol_create_region(struct wl_client *client, struct wl_resource *resource,
+static void zwl_compositor_protocol_create_region(struct wl_client *client,
+                                                  struct wl_resource *resource,
                                                   uint32_t id)
 {
   UNUSED(resource);
@@ -51,7 +53,8 @@ static const struct wl_compositor_interface zwl_compositor_interface = {
     .create_region = zwl_compositor_protocol_create_region,
 };
 
-static void zwl_compositor_global_flush_handler(struct wl_listener *listener, void *data)
+static void zwl_compositor_global_flush_handler(struct wl_listener *listener,
+                                                void *data)
 {
   UNUSED(data);
   struct zwl_compositor *compositor;
@@ -69,12 +72,14 @@ static int zwl_compositor_zsurface_dispatch(int fd, uint32_t mask, void *data)
 
   while (zsurface_prepare_read(compositor->zsurface) == -1) {
     if (errno != EAGAIN) {
-      wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_IMPLEMENTATION,
+      wl_resource_post_error(compositor->resource,
+                             WL_DISPLAY_ERROR_IMPLEMENTATION,
                              "failed to prepare to read zsurface event");
       return -1;
     }
     if (zsurface_dispatch_pending(compositor->zsurface) == -1) {
-      wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_IMPLEMENTATION,
+      wl_resource_post_error(compositor->resource,
+                             WL_DISPLAY_ERROR_IMPLEMENTATION,
                              "failed to dispatch zsurface pending event");
       return -1;
     }
@@ -83,20 +88,23 @@ static int zwl_compositor_zsurface_dispatch(int fd, uint32_t mask, void *data)
   while (zsurface_flush(compositor->zsurface) == -1) {
     if (errno != EAGAIN) {
       zsurface_cancel_read(compositor->zsurface);
-      wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_IMPLEMENTATION,
+      wl_resource_post_error(compositor->resource,
+                             WL_DISPLAY_ERROR_IMPLEMENTATION,
                              "failed to flush zsurface request");
       return -1;
     }
   }
 
   if (zsurface_read_events(compositor->zsurface) == -1) {
-    wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_IMPLEMENTATION,
+    wl_resource_post_error(compositor->resource,
+                           WL_DISPLAY_ERROR_IMPLEMENTATION,
                            "failed to read zsurface event");
     return -1;
   }
 
   if (zsurface_dispatch_pending(compositor->zsurface) == -1) {
-    wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_IMPLEMENTATION,
+    wl_resource_post_error(compositor->resource,
+                           WL_DISPLAY_ERROR_IMPLEMENTATION,
                            "failed to dispatch zsurface pending event");
     return -1;
   }
@@ -104,7 +112,8 @@ static int zwl_compositor_zsurface_dispatch(int fd, uint32_t mask, void *data)
   return 0;
 }
 
-static void zwl_compositor_handle_seat_capabilities(void *data, struct zsurface *surface,
+static void zwl_compositor_handle_seat_capabilities(void *data,
+                                                    struct zsurface *surface,
                                                     uint32_t capabilities)
 {
   UNUSED(surface);
@@ -116,7 +125,8 @@ static void zwl_compositor_handle_seat_capabilities(void *data, struct zsurface 
     struct zwl_pointer *pointer;
     pointer = zwl_seat_ensure_pointer(seat, client);
     if (pointer == NULL)
-      wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_NO_MEMORY, "failed to create a pointer");
+      wl_resource_post_error(compositor->resource, WL_DISPLAY_ERROR_NO_MEMORY,
+                             "failed to create a pointer");
   } else if (!(capabilities & WL_SEAT_CAPABILITY_POINTER)) {
     zwl_seat_destroy_pointer(seat, client);
   }
@@ -126,23 +136,27 @@ static void zwl_compositor_handle_seat_capabilities(void *data, struct zsurface 
   zwl_seat_send_capabilities(seat, client);
 }
 
-static void zwl_compositor_handle_pointer_enter(void *data, struct zsurface_view *view, uint32_t x,
-                                                uint32_t y)
+static void zwl_compositor_handle_pointer_enter(void *data,
+                                                struct zsurface_view *view,
+                                                uint32_t x, uint32_t y)
 {
   struct zwl_compositor *compositor = data;
   struct zwl_seat *seat = compositor->compositor_global->seat;
-  struct zwl_pointer *pointer = zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
+  struct zwl_pointer *pointer =
+      zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
   struct zwl_surface *surface = zsurface_view_get_user_data(view);
   if (surface == NULL || pointer == NULL) return;
 
   zwl_pointer_send_enter(pointer, surface, x, y);
 }
 
-static void zwl_compositor_handle_pointer_motion(void *data, uint32_t x, uint32_t y)
+static void zwl_compositor_handle_pointer_motion(void *data, uint32_t x,
+                                                 uint32_t y)
 {
   struct zwl_compositor *compositor = data;
   struct zwl_seat *seat = compositor->compositor_global->seat;
-  struct zwl_pointer *pointer = zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
+  struct zwl_pointer *pointer =
+      zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
   if (pointer == NULL) return;
 
   zwl_pointer_send_motion(pointer, x, y);
@@ -152,18 +166,21 @@ static void zwl_compositor_handle_leave(void *data, struct zsurface_view *view)
 {
   struct zwl_compositor *compositor = data;
   struct zwl_seat *seat = compositor->compositor_global->seat;
-  struct zwl_pointer *pointer = zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
+  struct zwl_pointer *pointer =
+      zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
   struct zwl_surface *surface = zsurface_view_get_user_data(view);
   if (surface == NULL || pointer == NULL) return;
 
   zwl_pointer_send_leave(pointer, surface);
 }
 
-static void zwl_compositor_handle_button(void *data, uint32_t button, uint32_t state)
+static void zwl_compositor_handle_button(void *data, uint32_t button,
+                                         uint32_t state)
 {
   struct zwl_compositor *compositor = data;
   struct zwl_seat *seat = compositor->compositor_global->seat;
-  struct zwl_pointer *pointer = zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
+  struct zwl_pointer *pointer =
+      zwl_seat_get_pointer(seat, wl_resource_get_client(compositor->resource));
   if (pointer == NULL) return;
 
   zwl_pointer_send_button(pointer, button, state);
@@ -177,8 +194,9 @@ static const struct zsurface_interface zsurface_interface = {
     .pointer_button = zwl_compositor_handle_button,
 };
 
-struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t version, uint32_t id,
-                                             struct zwl_compositor_global *compositor_global)
+struct zwl_compositor *zwl_compositor_create(
+    struct wl_client *client, uint32_t version, uint32_t id,
+    struct zwl_compositor_global *compositor_global)
 {
   UNUSED(compositor_global);
   struct zwl_compositor *compositor;
@@ -192,14 +210,16 @@ struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t 
     goto out;
   }
 
-  compositor->zsurface = zsurface_create("z11-0", compositor, &zsurface_interface);
+  compositor->zsurface =
+      zsurface_create("z11-0", compositor, &zsurface_interface);
   if (compositor->zsurface == NULL) {
     wl_client_post_no_memory(client);
     goto out_compositor;
   }
 
   if (zsurface_check_globals(compositor->zsurface) != 0) {
-    wl_client_post_implementation_error(client, "the compositor does not support the needed protocols");
+    wl_client_post_implementation_error(
+        client, "the compositor does not support the needed protocols");
     goto out_zsurface;
   }
 
@@ -209,8 +229,8 @@ struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t 
     goto out_zsurface;
   }
 
-  wl_resource_set_implementation(resource, &zwl_compositor_interface, compositor,
-                                 zwl_compositor_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_compositor_interface,
+                                 compositor, zwl_compositor_handle_destroy);
 
   compositor->resource = resource;
   compositor->display = compositor_global->display;
@@ -220,10 +240,13 @@ struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t 
   fd = zsurface_get_fd(compositor->zsurface);
 
   compositor->event_source =
-      wl_event_loop_add_fd(loop, fd, WL_EVENT_READABLE, zwl_compositor_zsurface_dispatch, compositor);
+      wl_event_loop_add_fd(loop, fd, WL_EVENT_READABLE,
+                           zwl_compositor_zsurface_dispatch, compositor);
 
-  compositor->global_flush_listener.notify = zwl_compositor_global_flush_handler;
-  wl_signal_add(&compositor_global->flush_signal, &compositor->global_flush_listener);
+  compositor->global_flush_listener.notify =
+      zwl_compositor_global_flush_handler;
+  wl_signal_add(&compositor_global->flush_signal,
+                &compositor->global_flush_listener);
 
   wl_signal_init(&compositor->destroy_signal);
 

--- a/server/compositor.h
+++ b/server/compositor.h
@@ -15,7 +15,8 @@ struct zwl_compositor {
   struct zwl_compositor_global *compositor_global;
 };
 
-struct zwl_compositor *zwl_compositor_create(struct wl_client *client, uint32_t version, uint32_t id,
-                                             struct zwl_compositor_global *compositor_global);
+struct zwl_compositor *zwl_compositor_create(
+    struct wl_client *client, uint32_t version, uint32_t id,
+    struct zwl_compositor_global *compositor_global);
 
 #endif  //  ZWAYLAND_COMPOSITOR_H

--- a/server/compositor_global.c
+++ b/server/compositor_global.c
@@ -6,7 +6,8 @@
 #include "compositor.h"
 #include "util.h"
 
-static void zwl_compositor_global_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_compositor_global_bind(struct wl_client *client, void *data,
+                                       uint32_t version, uint32_t id)
 {
   struct zwl_compositor_global *compositor_global = data;
   struct zwl_compositor *compositor;
@@ -17,7 +18,8 @@ static void zwl_compositor_global_bind(struct wl_client *client, void *data, uin
   }
 }
 
-struct zwl_compositor_global *zwl_compositor_global_create(struct wl_display *display)
+struct zwl_compositor_global *zwl_compositor_global_create(
+    struct wl_display *display)
 {
   struct zwl_compositor_global *compositor_global;
   struct wl_global *global;
@@ -25,8 +27,8 @@ struct zwl_compositor_global *zwl_compositor_global_create(struct wl_display *di
   compositor_global = zalloc(sizeof *compositor_global);
   if (compositor_global == NULL) goto out;
 
-  global =
-      wl_global_create(display, &wl_compositor_interface, 4, compositor_global, zwl_compositor_global_bind);
+  global = wl_global_create(display, &wl_compositor_interface, 4,
+                            compositor_global, zwl_compositor_global_bind);
   if (global == NULL) goto out_compositor;
 
   compositor_global->display = display;

--- a/server/compositor_global.h
+++ b/server/compositor_global.h
@@ -11,6 +11,7 @@ struct zwl_compositor_global {
   struct zwl_seat *seat;
 };
 
-struct zwl_compositor_global *zwl_compositor_global_create(struct wl_display *display);
+struct zwl_compositor_global *zwl_compositor_global_create(
+    struct wl_display *display);
 
 #endif  //  ZWAYLAND_COMPOSITOR_GLOBAL_H

--- a/server/keyboard.c
+++ b/server/keyboard.c
@@ -15,7 +15,8 @@ static void zwl_keyboard_handle_destroy(struct wl_resource *resource)
   zwl_keyboard_destroy(keyboard);
 }
 
-static void zwl_keyboard_protocol_release(struct wl_client *client, struct wl_resource *resource)
+static void zwl_keyboard_protocol_release(struct wl_client *client,
+                                          struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -42,7 +43,8 @@ struct zwl_keyboard *zwl_keyboard_create(struct wl_client *client, uint32_t id)
     goto out_keyboard;
   }
 
-  wl_resource_set_implementation(resource, &zwl_keyboard_interface, keyboard, zwl_keyboard_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_keyboard_interface, keyboard,
+                                 zwl_keyboard_handle_destroy);
 
   return keyboard;
 
@@ -53,4 +55,7 @@ out:
   return NULL;
 }
 
-static void zwl_keyboard_destroy(struct zwl_keyboard *keyboard) { free(keyboard); }
+static void zwl_keyboard_destroy(struct zwl_keyboard *keyboard)
+{
+  free(keyboard);
+}

--- a/server/output.c
+++ b/server/output.c
@@ -4,7 +4,8 @@
 
 #include "util.h"
 
-static void zwl_output_protocol_release(struct wl_client *client, struct wl_resource *resource)
+static void zwl_output_protocol_release(struct wl_client *client,
+                                        struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -14,7 +15,8 @@ static const struct wl_output_interface zwl_output_interface = {
     .release = zwl_output_protocol_release,
 };
 
-static void zwl_output_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_output_bind(struct wl_client *client, void *data,
+                            uint32_t version, uint32_t id)
 {
   struct zwl_output *output = data;
   struct wl_resource *resource;
@@ -29,10 +31,13 @@ static void zwl_output_bind(struct wl_client *client, void *data, uint32_t versi
   const int height = 1080;
   wl_resource_set_implementation(resource, &zwl_output_interface, output, NULL);
 
-  wl_output_send_geometry(resource, 0, 0, width, height, WL_OUTPUT_SUBPIXEL_UNKNOWN, "z11", "zwayland",
+  wl_output_send_geometry(resource, 0, 0, width, height,
+                          WL_OUTPUT_SUBPIXEL_UNKNOWN, "z11", "zwayland",
                           WL_OUTPUT_TRANSFORM_NORMAL);
   wl_output_send_scale(resource, 1);
-  wl_output_send_mode(resource, WL_OUTPUT_MODE_CURRENT | WL_OUTPUT_MODE_PREFERRED, width, height, 60000);
+  wl_output_send_mode(resource,
+                      WL_OUTPUT_MODE_CURRENT | WL_OUTPUT_MODE_PREFERRED, width,
+                      height, 60000);
   wl_output_send_done(resource);
 }
 
@@ -44,7 +49,8 @@ struct zwl_output *zwl_output_create(struct wl_display *display)
   output = zalloc(sizeof *output);
   if (output == NULL) goto out;
 
-  global = wl_global_create(display, &wl_output_interface, 3, output, zwl_output_bind);
+  global = wl_global_create(display, &wl_output_interface, 3, output,
+                            zwl_output_bind);
   if (global == NULL) goto out_output;
 
   return output;

--- a/server/pointer.c
+++ b/server/pointer.c
@@ -7,9 +7,9 @@
 #include "surface.h"
 #include "util.h"
 
-static void zwl_pointer_protocol_set_cursor(struct wl_client *client, struct wl_resource *resource,
-                                            uint32_t serial, struct wl_resource *surface, int32_t hotspot_x,
-                                            int32_t hotspot_y)
+static void zwl_pointer_protocol_set_cursor(
+    struct wl_client *client, struct wl_resource *resource, uint32_t serial,
+    struct wl_resource *surface, int32_t hotspot_x, int32_t hotspot_y)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -19,7 +19,8 @@ static void zwl_pointer_protocol_set_cursor(struct wl_client *client, struct wl_
   UNUSED(hotspot_y);
 }
 
-static void zwl_pointer_protocol_release(struct wl_client *client, struct wl_resource *resource)
+static void zwl_pointer_protocol_release(struct wl_client *client,
+                                         struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
@@ -30,7 +31,8 @@ static const struct wl_pointer_interface zwl_pointer_interface = {
     .release = zwl_pointer_protocol_release,
 };
 
-void zwl_pointer_send_enter(struct zwl_pointer *pointer, struct zwl_surface *surface, uint32_t x, uint32_t y)
+void zwl_pointer_send_enter(struct zwl_pointer *pointer,
+                            struct zwl_surface *surface, uint32_t x, uint32_t y)
 {
   struct wl_resource *resource;
   struct wl_display *display = wl_client_get_display(pointer->client);
@@ -38,11 +40,13 @@ void zwl_pointer_send_enter(struct zwl_pointer *pointer, struct zwl_surface *sur
 
   wl_resource_for_each(resource, &pointer->resource_list)
   {
-    wl_pointer_send_enter(resource, serial, surface->resource, wl_fixed_from_int(x), wl_fixed_from_int(y));
+    wl_pointer_send_enter(resource, serial, surface->resource,
+                          wl_fixed_from_int(x), wl_fixed_from_int(y));
   }
 }
 
-void zwl_pointer_send_motion(struct zwl_pointer *pointer, uint32_t x, uint32_t y)
+void zwl_pointer_send_motion(struct zwl_pointer *pointer, uint32_t x,
+                             uint32_t y)
 {
   struct wl_resource *resource;
   struct timeval tv;
@@ -53,11 +57,13 @@ void zwl_pointer_send_motion(struct zwl_pointer *pointer, uint32_t x, uint32_t y
 
   wl_resource_for_each(resource, &pointer->resource_list)
   {
-    wl_pointer_send_motion(resource, current_time_in_milles, wl_fixed_from_int(x), wl_fixed_from_int(y));
+    wl_pointer_send_motion(resource, current_time_in_milles,
+                           wl_fixed_from_int(x), wl_fixed_from_int(y));
   }
 }
 
-void zwl_pointer_send_leave(struct zwl_pointer *pointer, struct zwl_surface *surface)
+void zwl_pointer_send_leave(struct zwl_pointer *pointer,
+                            struct zwl_surface *surface)
 {
   struct wl_resource *resource;
   struct wl_display *display = wl_client_get_display(pointer->client);
@@ -69,7 +75,8 @@ void zwl_pointer_send_leave(struct zwl_pointer *pointer, struct zwl_surface *sur
   }
 }
 
-void zwl_pointer_send_button(struct zwl_pointer *pointer, uint32_t button, uint32_t state)
+void zwl_pointer_send_button(struct zwl_pointer *pointer, uint32_t button,
+                             uint32_t state)
 {
   struct wl_resource *resource;
   struct wl_display *display = wl_client_get_display(pointer->client);
@@ -82,7 +89,8 @@ void zwl_pointer_send_button(struct zwl_pointer *pointer, uint32_t button, uint3
 
   wl_resource_for_each(resource, &pointer->resource_list)
   {
-    wl_pointer_send_button(resource, serial, current_time_in_milles, button, state);
+    wl_pointer_send_button(resource, serial, current_time_in_milles, button,
+                           state);
   }
 }
 
@@ -91,7 +99,8 @@ static void zwl_pointer_handle_destroy(struct wl_resource *resource)
   wl_list_remove(wl_resource_get_link(resource));
 }
 
-struct wl_resource *zwl_pointer_add_resource(struct zwl_pointer *pointer, struct wl_client *client,
+struct wl_resource *zwl_pointer_add_resource(struct zwl_pointer *pointer,
+                                             struct wl_client *client,
                                              uint32_t id)
 {
   struct wl_resource *resource;
@@ -104,12 +113,14 @@ struct wl_resource *zwl_pointer_add_resource(struct zwl_pointer *pointer, struct
 
   wl_list_insert(&pointer->resource_list, wl_resource_get_link(resource));
 
-  wl_resource_set_implementation(resource, &zwl_pointer_interface, pointer, zwl_pointer_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_pointer_interface, pointer,
+                                 zwl_pointer_handle_destroy);
 
   return resource;
 }
 
-static void zwl_pointer_client_destroy_handler(struct wl_listener *listener, void *data)
+static void zwl_pointer_client_destroy_handler(struct wl_listener *listener,
+                                               void *data)
 {
   UNUSED(data);
   struct zwl_pointer *pointer;
@@ -119,7 +130,8 @@ static void zwl_pointer_client_destroy_handler(struct wl_listener *listener, voi
   zwl_pointer_destroy(pointer);
 }
 
-struct zwl_pointer *zwl_pointer_create(struct wl_client *client, struct zwl_seat *seat)
+struct zwl_pointer *zwl_pointer_create(struct wl_client *client,
+                                       struct zwl_seat *seat)
 {
   struct zwl_pointer *pointer;
 

--- a/server/pointer.h
+++ b/server/pointer.h
@@ -13,19 +13,26 @@ struct zwl_pointer {
   struct wl_listener client_destroy_listener;
 };
 
-struct zwl_pointer *zwl_pointer_create(struct wl_client *client, struct zwl_seat *seat);
+struct zwl_pointer *zwl_pointer_create(struct wl_client *client,
+                                       struct zwl_seat *seat);
 
 void zwl_pointer_destroy(struct zwl_pointer *pointer);
 
-struct wl_resource *zwl_pointer_add_resource(struct zwl_pointer *pointer, struct wl_client *client,
+struct wl_resource *zwl_pointer_add_resource(struct zwl_pointer *pointer,
+                                             struct wl_client *client,
                                              uint32_t id);
 
-void zwl_pointer_send_enter(struct zwl_pointer *pointer, struct zwl_surface *surface, uint32_t x, uint32_t y);
+void zwl_pointer_send_enter(struct zwl_pointer *pointer,
+                            struct zwl_surface *surface, uint32_t x,
+                            uint32_t y);
 
-void zwl_pointer_send_motion(struct zwl_pointer *pointer, uint32_t x, uint32_t y);
+void zwl_pointer_send_motion(struct zwl_pointer *pointer, uint32_t x,
+                             uint32_t y);
 
-void zwl_pointer_send_leave(struct zwl_pointer *pointer, struct zwl_surface *surface);
+void zwl_pointer_send_leave(struct zwl_pointer *pointer,
+                            struct zwl_surface *surface);
 
-void zwl_pointer_send_button(struct zwl_pointer *pointer, uint32_t button, uint32_t state);
+void zwl_pointer_send_button(struct zwl_pointer *pointer, uint32_t button,
+                             uint32_t state);
 
 #endif  //  ZWAYLAND_POINTER_H

--- a/server/region.c
+++ b/server/region.c
@@ -15,13 +15,15 @@ static void zwl_region_handle_destroy(struct wl_resource* resource)
   zwl_region_destroy(region);
 }
 
-static void zwl_region_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
+static void zwl_region_protocol_destroy(struct wl_client* client,
+                                        struct wl_resource* resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
 
-static void zwl_region_protocol_add(struct wl_client* client, struct wl_resource* resource, int32_t x,
+static void zwl_region_protocol_add(struct wl_client* client,
+                                    struct wl_resource* resource, int32_t x,
                                     int32_t y, int32_t width, int32_t height)
 {
   UNUSED(client);
@@ -32,8 +34,10 @@ static void zwl_region_protocol_add(struct wl_client* client, struct wl_resource
   UNUSED(height);
 }
 
-static void zwl_region_protocol_subtract(struct wl_client* client, struct wl_resource* resource, int32_t x,
-                                         int32_t y, int32_t width, int32_t height)
+static void zwl_region_protocol_subtract(struct wl_client* client,
+                                         struct wl_resource* resource,
+                                         int32_t x, int32_t y, int32_t width,
+                                         int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -66,7 +70,8 @@ struct zwl_region* zwl_region_create(struct wl_client* client, uint32_t id)
     goto out_region;
   }
 
-  wl_resource_set_implementation(resource, &zwl_region_interface, region, zwl_region_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_region_interface, region,
+                                 zwl_region_handle_destroy);
 
   return region;
 

--- a/server/seat.c
+++ b/server/seat.c
@@ -7,7 +7,8 @@
 #include "pointer.h"
 #include "util.h"
 
-struct zwl_pointer *zwl_seat_get_pointer(struct zwl_seat *seat, struct wl_client *client)
+struct zwl_pointer *zwl_seat_get_pointer(struct zwl_seat *seat,
+                                         struct wl_client *client)
 {
   struct zwl_pointer *pointer;
 
@@ -19,7 +20,8 @@ struct zwl_pointer *zwl_seat_get_pointer(struct zwl_seat *seat, struct wl_client
   return NULL;
 }
 
-struct zwl_pointer *zwl_seat_ensure_pointer(struct zwl_seat *seat, struct wl_client *client)
+struct zwl_pointer *zwl_seat_ensure_pointer(struct zwl_seat *seat,
+                                            struct wl_client *client)
 {
   struct zwl_pointer *pointer;
 
@@ -45,15 +47,19 @@ void zwl_seat_send_capabilities(struct zwl_seat *seat, struct wl_client *client)
 {
   struct wl_resource *resource;
   uint32_t capabilities = 0;
-  if (zwl_seat_get_pointer(seat, client)) capabilities |= WL_SEAT_CAPABILITY_POINTER;
+  if (zwl_seat_get_pointer(seat, client))
+    capabilities |= WL_SEAT_CAPABILITY_POINTER;
 
   wl_resource_for_each(resource, &seat->resource_list)
   {
-    if (wl_resource_get_client(resource) == client) wl_seat_send_capabilities(resource, capabilities);
+    if (wl_resource_get_client(resource) == client)
+      wl_seat_send_capabilities(resource, capabilities);
   }
 }
 
-static void zwl_seat_protocol_get_pointer(struct wl_client *client, struct wl_resource *resource, uint32_t id)
+static void zwl_seat_protocol_get_pointer(struct wl_client *client,
+                                          struct wl_resource *resource,
+                                          uint32_t id)
 {
   struct zwl_seat *seat = wl_resource_get_user_data(resource);
   struct zwl_pointer *pointer = zwl_seat_get_pointer(seat, client);
@@ -65,11 +71,13 @@ static void zwl_seat_protocol_get_pointer(struct wl_client *client, struct wl_re
     fprintf(stderr, "called get_pointer but no pointer capability\n");
   } else {
     pointer_resource = zwl_pointer_add_resource(pointer, client, id);
-    if (pointer_resource == NULL) fprintf(stderr, "failed to create a pointer resource\n");
+    if (pointer_resource == NULL)
+      fprintf(stderr, "failed to create a pointer resource\n");
   }
 }
 
-static void zwl_seat_protocol_get_keyboard(struct wl_client *client, struct wl_resource *resource,
+static void zwl_seat_protocol_get_keyboard(struct wl_client *client,
+                                           struct wl_resource *resource,
                                            uint32_t id)
 {
   UNUSED(resource);
@@ -81,14 +89,17 @@ static void zwl_seat_protocol_get_keyboard(struct wl_client *client, struct wl_r
   }
 }
 
-static void zwl_seat_protocol_get_touch(struct wl_client *client, struct wl_resource *resource, uint32_t id)
+static void zwl_seat_protocol_get_touch(struct wl_client *client,
+                                        struct wl_resource *resource,
+                                        uint32_t id)
 {
   UNUSED(client);
   UNUSED(resource);
   UNUSED(id);
 }
 
-static void zwl_seat_protocol_release(struct wl_client *client, struct wl_resource *resource)
+static void zwl_seat_protocol_release(struct wl_client *client,
+                                      struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -106,7 +117,8 @@ static void zwl_seat_handle_destroy(struct wl_resource *resource)
   wl_list_remove(wl_resource_get_link(resource));
 }
 
-static void zwl_seat_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_seat_bind(struct wl_client *client, void *data,
+                          uint32_t version, uint32_t id)
 {
   struct zwl_seat *seat = data;
   struct wl_resource *resource;
@@ -117,7 +129,8 @@ static void zwl_seat_bind(struct wl_client *client, void *data, uint32_t version
     return;
   }
 
-  wl_resource_set_implementation(resource, &zwl_seat_interface, seat, zwl_seat_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_seat_interface, seat,
+                                 zwl_seat_handle_destroy);
 
   wl_list_insert(&seat->resource_list, wl_resource_get_link(resource));
 
@@ -133,7 +146,8 @@ struct zwl_seat *zwl_seat_create(struct wl_display *display)
   seat = zalloc(sizeof *seat);
   if (seat == NULL) goto out;
 
-  global = wl_global_create(display, &wl_seat_interface, 3, seat, zwl_seat_bind);
+  global =
+      wl_global_create(display, &wl_seat_interface, 3, seat, zwl_seat_bind);
   if (global == NULL) goto out_seat;
 
   wl_list_init(&seat->pointer_list);

--- a/server/seat.h
+++ b/server/seat.h
@@ -9,13 +9,16 @@ struct zwl_seat {
 };
 
 // nullable
-struct zwl_pointer* zwl_seat_get_pointer(struct zwl_seat* seat, struct wl_client* client);
+struct zwl_pointer* zwl_seat_get_pointer(struct zwl_seat* seat,
+                                         struct wl_client* client);
 
-struct zwl_pointer* zwl_seat_ensure_pointer(struct zwl_seat* seat, struct wl_client* client);
+struct zwl_pointer* zwl_seat_ensure_pointer(struct zwl_seat* seat,
+                                            struct wl_client* client);
 
 void zwl_seat_destroy_pointer(struct zwl_seat* seat, struct wl_client* client);
 
-void zwl_seat_send_capabilities(struct zwl_seat* seat, struct wl_client* client);
+void zwl_seat_send_capabilities(struct zwl_seat* seat,
+                                struct wl_client* client);
 
 struct zwl_seat* zwl_seat_create(struct wl_display* display);
 

--- a/server/shell.c
+++ b/server/shell.c
@@ -7,8 +7,9 @@
 #include "shell_surface.h"
 #include "util.h"
 
-static void zwl_shell_protocol_get_shell_surface(struct wl_client *client, struct wl_resource *resource,
-                                                 uint32_t id, struct wl_resource *surface_resource)
+static void zwl_shell_protocol_get_shell_surface(
+    struct wl_client *client, struct wl_resource *resource, uint32_t id,
+    struct wl_resource *surface_resource)
 {
   UNUSED(resource);
   struct zwl_surface *surface = wl_resource_get_user_data(surface_resource);
@@ -24,7 +25,8 @@ static const struct wl_shell_interface zwl_shell_interface = {
     .get_shell_surface = zwl_shell_protocol_get_shell_surface,
 };
 
-static void zwl_shell_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_shell_bind(struct wl_client *client, void *data,
+                           uint32_t version, uint32_t id)
 {
   struct zwl_shell *shell = data;
   struct wl_resource *resource;
@@ -46,7 +48,8 @@ struct zwl_shell *zwl_shell_create(struct wl_display *display)
   shell = zalloc(sizeof *shell);
   if (shell == NULL) goto out;
 
-  global = wl_global_create(display, &wl_shell_interface, 1, shell, zwl_shell_bind);
+  global =
+      wl_global_create(display, &wl_shell_interface, 1, shell, zwl_shell_bind);
   if (global == NULL) goto out_shell;
 
   return shell;

--- a/server/shell_surface.c
+++ b/server/shell_surface.c
@@ -18,7 +18,8 @@ static void zwl_shell_surface_handle_destroy(struct wl_resource *resource)
   zwl_shell_surface_destroy(shell_surface);
 }
 
-static void zwl_shell_surface_protocol_pong(struct wl_client *client, struct wl_resource *resource,
+static void zwl_shell_surface_protocol_pong(struct wl_client *client,
+                                            struct wl_resource *resource,
                                             uint32_t serial)
 {
   UNUSED(client);
@@ -26,8 +27,10 @@ static void zwl_shell_surface_protocol_pong(struct wl_client *client, struct wl_
   UNUSED(serial);
 }
 
-static void zwl_shell_surface_protocol_move(struct wl_client *client, struct wl_resource *resource,
-                                            struct wl_resource *seat, uint32_t serial)
+static void zwl_shell_surface_protocol_move(struct wl_client *client,
+                                            struct wl_resource *resource,
+                                            struct wl_resource *seat,
+                                            uint32_t serial)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -35,8 +38,10 @@ static void zwl_shell_surface_protocol_move(struct wl_client *client, struct wl_
   UNUSED(serial);
 }
 
-static void zwl_shell_surface_protocol_resize(struct wl_client *client, struct wl_resource *resource,
-                                              struct wl_resource *seat, uint32_t serial, uint32_t edges)
+static void zwl_shell_surface_protocol_resize(struct wl_client *client,
+                                              struct wl_resource *resource,
+                                              struct wl_resource *seat,
+                                              uint32_t serial, uint32_t edges)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -45,7 +50,8 @@ static void zwl_shell_surface_protocol_resize(struct wl_client *client, struct w
   UNUSED(edges);
 }
 
-static void zwl_shell_surface_protocol_set_toplevel(struct wl_client *client, struct wl_resource *resource)
+static void zwl_shell_surface_protocol_set_toplevel(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   struct zwl_shell_surface *shell_surface;
@@ -55,9 +61,9 @@ static void zwl_shell_surface_protocol_set_toplevel(struct wl_client *client, st
   shell_surface->role = toplevel;
 }
 
-static void zwl_shell_surface_protocol_set_transient(struct wl_client *client, struct wl_resource *resource,
-                                                     struct wl_resource *parent, int32_t x, int32_t y,
-                                                     uint32_t flags)
+static void zwl_shell_surface_protocol_set_transient(
+    struct wl_client *client, struct wl_resource *resource,
+    struct wl_resource *parent, int32_t x, int32_t y, uint32_t flags)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -67,9 +73,9 @@ static void zwl_shell_surface_protocol_set_transient(struct wl_client *client, s
   UNUSED(flags);
 }
 
-static void zwl_shell_surface_protocol_set_fullscreen(struct wl_client *client, struct wl_resource *resource,
-                                                      uint32_t method, uint32_t framerate,
-                                                      struct wl_resource *output)
+static void zwl_shell_surface_protocol_set_fullscreen(
+    struct wl_client *client, struct wl_resource *resource, uint32_t method,
+    uint32_t framerate, struct wl_resource *output)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -78,10 +84,10 @@ static void zwl_shell_surface_protocol_set_fullscreen(struct wl_client *client, 
   UNUSED(output);
 }
 
-static void zwl_shell_surface_protocol_set_popup(struct wl_client *client, struct wl_resource *resource,
-                                                 struct wl_resource *seat, uint32_t serial,
-                                                 struct wl_resource *parent, int32_t x, int32_t y,
-                                                 uint32_t flags)
+static void zwl_shell_surface_protocol_set_popup(
+    struct wl_client *client, struct wl_resource *resource,
+    struct wl_resource *seat, uint32_t serial, struct wl_resource *parent,
+    int32_t x, int32_t y, uint32_t flags)
 {
   UNUSED(client);
   UNUSED(seat);
@@ -97,15 +103,17 @@ static void zwl_shell_surface_protocol_set_popup(struct wl_client *client, struc
   shell_surface->role = popup;
 }
 
-static void zwl_shell_surface_protocol_set_maximaized(struct wl_client *client, struct wl_resource *resource,
-                                                      struct wl_resource *output)
+static void zwl_shell_surface_protocol_set_maximaized(
+    struct wl_client *client, struct wl_resource *resource,
+    struct wl_resource *output)
 {
   UNUSED(client);
   UNUSED(resource);
   UNUSED(output);
 }
 
-static void zwl_shell_surface_protocol_set_title(struct wl_client *client, struct wl_resource *resource,
+static void zwl_shell_surface_protocol_set_title(struct wl_client *client,
+                                                 struct wl_resource *resource,
                                                  const char *title)
 {
   UNUSED(client);
@@ -113,7 +121,8 @@ static void zwl_shell_surface_protocol_set_title(struct wl_client *client, struc
   UNUSED(title);
 }
 
-static void zwl_shell_surface_protocol_set_class(struct wl_client *client, struct wl_resource *resource,
+static void zwl_shell_surface_protocol_set_class(struct wl_client *client,
+                                                 struct wl_resource *resource,
                                                  const char *class_)
 {
   UNUSED(client);
@@ -134,13 +143,15 @@ static const struct wl_shell_surface_interface zwl_shell_surface_interface = {
     .set_class = zwl_shell_surface_protocol_set_class,
 };
 
-static void zwl_shell_surface_surface_commit_handler(struct wl_listener *listener, void *data)
+static void zwl_shell_surface_surface_commit_handler(
+    struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zwl_shell_surface *shell_surface;
   struct zwl_surface *surface;
 
-  shell_surface = wl_container_of(listener, shell_surface, surface_commit_listener);
+  shell_surface =
+      wl_container_of(listener, shell_surface, surface_commit_listener);
   if (shell_surface->role != toplevel) {
     return;
   }
@@ -148,7 +159,8 @@ static void zwl_shell_surface_surface_commit_handler(struct wl_listener *listene
   surface = shell_surface->surface;
 
   if (surface->pending.buffer_resource != NULL) {
-    struct wl_shm_buffer *shm_buffer = wl_shm_buffer_get(surface->pending.buffer_resource);
+    struct wl_shm_buffer *shm_buffer =
+        wl_shm_buffer_get(surface->pending.buffer_resource);
     enum wl_shm_format format = wl_shm_buffer_get_format(shm_buffer);
     uint32_t stride = wl_shm_buffer_get_stride(shm_buffer);
     uint32_t width = wl_shm_buffer_get_width(shm_buffer);
@@ -164,10 +176,12 @@ static void zwl_shell_surface_surface_commit_handler(struct wl_listener *listene
     wl_shm_buffer_end_access(shm_buffer);
   }
 
-  if (surface->pending.buffer_resource != NULL) wl_buffer_send_release(surface->pending.buffer_resource);
+  if (surface->pending.buffer_resource != NULL)
+    wl_buffer_send_release(surface->pending.buffer_resource);
 }
 
-static void zwl_shell_surface_virtual_object_callback_done(void *data, uint32_t callback_time)
+static void zwl_shell_surface_virtual_object_callback_done(
+    void *data, uint32_t callback_time)
 {
   struct zwl_callback *callback = data;
 
@@ -175,12 +189,14 @@ static void zwl_shell_surface_virtual_object_callback_done(void *data, uint32_t 
   wl_resource_destroy(callback->resource);
 }
 
-static void zwl_shell_surface_surface_frame_handler(struct wl_listener *listener, void *data)
+static void zwl_shell_surface_surface_frame_handler(
+    struct wl_listener *listener, void *data)
 {
   struct zwl_callback *callback = data;
   struct zwl_shell_surface *shell_surface;
 
-  shell_surface = wl_container_of(listener, shell_surface, surface_frame_listener);
+  shell_surface =
+      wl_container_of(listener, shell_surface, surface_frame_listener);
 
   // TODO: implement
   (void)zwl_shell_surface_virtual_object_callback_done;
@@ -188,17 +204,20 @@ static void zwl_shell_surface_surface_frame_handler(struct wl_listener *listener
   (void)shell_surface;
 }
 
-static void zwl_shell_surface_surface_destroy_handler(struct wl_listener *listener, void *data)
+static void zwl_shell_surface_surface_destroy_handler(
+    struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zwl_shell_surface *shell_surface;
 
-  shell_surface = wl_container_of(listener, shell_surface, surface_destroy_listener);
+  shell_surface =
+      wl_container_of(listener, shell_surface, surface_destroy_listener);
 
   wl_resource_destroy(shell_surface->resource);
 }
 
-struct zwl_shell_surface *zwl_shell_surface_create(struct wl_client *client, uint32_t id,
+struct zwl_shell_surface *zwl_shell_surface_create(struct wl_client *client,
+                                                   uint32_t id,
                                                    struct zwl_surface *surface)
 {
   UNUSED(surface);
@@ -217,21 +236,28 @@ struct zwl_shell_surface *zwl_shell_surface_create(struct wl_client *client, uin
     goto out_shell_surface;
   }
 
-  wl_resource_set_implementation(resource, &zwl_shell_surface_interface, shell_surface,
+  wl_resource_set_implementation(resource, &zwl_shell_surface_interface,
+                                 shell_surface,
                                  zwl_shell_surface_handle_destroy);
 
   shell_surface->resource = resource;
   shell_surface->surface = surface;
   shell_surface->role = none;
 
-  shell_surface->surface_commit_listener.notify = zwl_shell_surface_surface_commit_handler;
-  wl_signal_add(&shell_surface->surface->commit_signal, &shell_surface->surface_commit_listener);
+  shell_surface->surface_commit_listener.notify =
+      zwl_shell_surface_surface_commit_handler;
+  wl_signal_add(&shell_surface->surface->commit_signal,
+                &shell_surface->surface_commit_listener);
 
-  shell_surface->surface_frame_listener.notify = zwl_shell_surface_surface_frame_handler;
-  wl_signal_add(&shell_surface->surface->frame_signal, &shell_surface->surface_frame_listener);
+  shell_surface->surface_frame_listener.notify =
+      zwl_shell_surface_surface_frame_handler;
+  wl_signal_add(&shell_surface->surface->frame_signal,
+                &shell_surface->surface_frame_listener);
 
-  shell_surface->surface_destroy_listener.notify = zwl_shell_surface_surface_destroy_handler;
-  wl_signal_add(&shell_surface->surface->destroy_signal, &shell_surface->surface_destroy_listener);
+  shell_surface->surface_destroy_listener.notify =
+      zwl_shell_surface_surface_destroy_handler;
+  wl_signal_add(&shell_surface->surface->destroy_signal,
+                &shell_surface->surface_destroy_listener);
 
   return shell_surface;
 

--- a/server/shell_surface.h
+++ b/server/shell_surface.h
@@ -20,7 +20,8 @@ struct zwl_shell_surface {
   struct wl_listener surface_destroy_listener;
 };
 
-struct zwl_shell_surface *zwl_shell_surface_create(struct wl_client *client, uint32_t id,
+struct zwl_shell_surface *zwl_shell_surface_create(struct wl_client *client,
+                                                   uint32_t id,
                                                    struct zwl_surface *surface);
 
 #endif  //  ZWAYLAND_SHELL_SURFACE_H

--- a/server/surface.c
+++ b/server/surface.c
@@ -18,13 +18,16 @@ static void zwl_surface_handle_destroy(struct wl_resource *resource)
   zwl_surface_destroy(surface);
 }
 
-static void zwl_surface_protocol_destory(struct wl_client *client, struct wl_resource *resource)
+static void zwl_surface_protocol_destory(struct wl_client *client,
+                                         struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
-static void zwl_surface_protocol_attach(struct wl_client *client, struct wl_resource *resource,
-                                        struct wl_resource *buffer_resource, int32_t x, int32_t y)
+static void zwl_surface_protocol_attach(struct wl_client *client,
+                                        struct wl_resource *resource,
+                                        struct wl_resource *buffer_resource,
+                                        int32_t x, int32_t y)
 {
   UNUSED(client);
   UNUSED(x);
@@ -39,8 +42,10 @@ static void zwl_surface_protocol_attach(struct wl_client *client, struct wl_reso
   // TODO: implement more
 }
 
-static void zwl_surface_protocol_damage(struct wl_client *client, struct wl_resource *resource, int32_t x,
-                                        int32_t y, int32_t width, int32_t height)
+static void zwl_surface_protocol_damage(struct wl_client *client,
+                                        struct wl_resource *resource, int32_t x,
+                                        int32_t y, int32_t width,
+                                        int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -51,7 +56,8 @@ static void zwl_surface_protocol_damage(struct wl_client *client, struct wl_reso
   // TODO: implement
 }
 
-static void zwl_surface_protocol_frame(struct wl_client *client, struct wl_resource *resource,
+static void zwl_surface_protocol_frame(struct wl_client *client,
+                                       struct wl_resource *resource,
                                        uint32_t callback_id)
 {
   struct zwl_surface *surface = wl_resource_get_user_data(resource);
@@ -64,7 +70,8 @@ static void zwl_surface_protocol_frame(struct wl_client *client, struct wl_resou
   wl_signal_emit(&surface->frame_signal, callback);
 }
 
-static void zwl_surface_protocol_set_opaque_region(struct wl_client *client, struct wl_resource *resource,
+static void zwl_surface_protocol_set_opaque_region(struct wl_client *client,
+                                                   struct wl_resource *resource,
                                                    struct wl_resource *region)
 {
   UNUSED(client);
@@ -73,7 +80,8 @@ static void zwl_surface_protocol_set_opaque_region(struct wl_client *client, str
   // TODO: implement
 }
 
-static void zwl_surface_protocol_set_input_region(struct wl_client *client, struct wl_resource *resource,
+static void zwl_surface_protocol_set_input_region(struct wl_client *client,
+                                                  struct wl_resource *resource,
                                                   struct wl_resource *region)
 {
   UNUSED(client);
@@ -82,7 +90,8 @@ static void zwl_surface_protocol_set_input_region(struct wl_client *client, stru
   // TODO: implement
 }
 
-static void zwl_surface_protocol_commit(struct wl_client *client, struct wl_resource *resource)
+static void zwl_surface_protocol_commit(struct wl_client *client,
+                                        struct wl_resource *resource)
 {
   UNUSED(client);
   struct zwl_surface *surface;
@@ -92,8 +101,8 @@ static void zwl_surface_protocol_commit(struct wl_client *client, struct wl_reso
   wl_signal_emit(&surface->commit_signal, NULL);
 }
 
-static void zwl_surface_protocol_set_buffer_transform(struct wl_client *client, struct wl_resource *resource,
-                                                      int32_t transform)
+static void zwl_surface_protocol_set_buffer_transform(
+    struct wl_client *client, struct wl_resource *resource, int32_t transform)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -101,7 +110,8 @@ static void zwl_surface_protocol_set_buffer_transform(struct wl_client *client, 
   // TODO: implement
 }
 
-static void zwl_surface_protocol_set_buffer_scale(struct wl_client *client, struct wl_resource *resource,
+static void zwl_surface_protocol_set_buffer_scale(struct wl_client *client,
+                                                  struct wl_resource *resource,
                                                   int32_t scale)
 {
   UNUSED(client);
@@ -110,8 +120,10 @@ static void zwl_surface_protocol_set_buffer_scale(struct wl_client *client, stru
   // TODO: implement
 }
 
-static void zwl_surface_protocol_damage_buffer(struct wl_client *client, struct wl_resource *resource,
-                                               int32_t x, int32_t y, int32_t width, int32_t height)
+static void zwl_surface_protocol_damage_buffer(struct wl_client *client,
+                                               struct wl_resource *resource,
+                                               int32_t x, int32_t y,
+                                               int32_t width, int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -135,7 +147,8 @@ static const struct wl_surface_interface zwl_surface_interface = {
     .damage_buffer = zwl_surface_protocol_damage_buffer,
 };
 
-static void zwl_surface_compositor_destroy_handler(struct wl_listener *listener, void *data)
+static void zwl_surface_compositor_destroy_handler(struct wl_listener *listener,
+                                                   void *data)
 {
   UNUSED(data);
   struct zwl_surface *surface;
@@ -162,7 +175,8 @@ struct zwl_surface *zwl_surface_create(struct wl_client *client, uint32_t id,
     wl_client_post_no_memory(client);
     goto out_surface;
   }
-  wl_resource_set_implementation(resource, &zwl_surface_interface, surface, zwl_surface_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_surface_interface, surface,
+                                 zwl_surface_handle_destroy);
 
   surface->resource = resource;
 
@@ -171,8 +185,10 @@ struct zwl_surface *zwl_surface_create(struct wl_client *client, uint32_t id,
   wl_signal_init(&surface->destroy_signal);
 
   surface->compositor = compositor;
-  surface->compositor_destroy_listener.notify = zwl_surface_compositor_destroy_handler;
-  wl_signal_add(&compositor->destroy_signal, &surface->compositor_destroy_listener);
+  surface->compositor_destroy_listener.notify =
+      zwl_surface_compositor_destroy_handler;
+  wl_signal_add(&compositor->destroy_signal,
+                &surface->compositor_destroy_listener);
 
   surface->pending.buffer_resource = NULL;
   // TODO: listen buffer resource destroy signal

--- a/server/util.c
+++ b/server/util.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 #include <wayland-server.h>
 
-static void zwl_week_pointer_handle_destroy_signal_handler(struct wl_listener* listener, void* data)
+static void zwl_week_pointer_handle_destroy_signal_handler(
+    struct wl_listener* listener, void* data)
 {
   UNUSED(data);
   struct zwl_week_ref* ref;
@@ -25,9 +26,13 @@ void zwl_week_ref_init(struct zwl_week_ref* ref)
   ref->destroy_func = NULL;
 }
 
-void zwl_week_ref_destroy(struct zwl_week_ref* ref) { wl_list_remove(&ref->destroy_listener.link); }
+void zwl_week_ref_destroy(struct zwl_week_ref* ref)
+{
+  wl_list_remove(&ref->destroy_listener.link);
+}
 
-void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data,
+                           struct wl_signal* destroy_signal,
                            zwl_week_ref_destroy_func_t on_destroy)
 {
   wl_list_remove(&ref->destroy_listener.link);

--- a/server/util.h
+++ b/server/util.h
@@ -23,7 +23,8 @@ void zwl_week_ref_init(struct zwl_week_ref* week_ref);
 
 void zwl_week_ref_destroy(struct zwl_week_ref* ref);
 
-void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+void zwl_week_ref_set_data(struct zwl_week_ref* ref, void* data,
+                           struct wl_signal* destroy_signal,
                            zwl_week_ref_destroy_func_t on_destroy);
 
 #endif  // ZWAYLAND_UTIL_H

--- a/server/xdg_popup.c
+++ b/server/xdg_popup.c
@@ -15,14 +15,17 @@ static void zwl_xdg_popup_handle_destroy(struct wl_resource *resource)
   zwl_xdg_popup_destroy(popup);
 }
 
-static void zwl_xdg_popup_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_popup_protocol_destroy(struct wl_client *client,
+                                           struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
 
-static void zwl_xdg_popup_protocol_grab(struct wl_client *client, struct wl_resource *resource,
-                                        struct wl_resource *seat, uint32_t serial)
+static void zwl_xdg_popup_protocol_grab(struct wl_client *client,
+                                        struct wl_resource *resource,
+                                        struct wl_resource *seat,
+                                        uint32_t serial)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -30,8 +33,10 @@ static void zwl_xdg_popup_protocol_grab(struct wl_client *client, struct wl_reso
   UNUSED(serial);
 }
 
-static void zwl_xdg_popup_protocol_reposition(struct wl_client *client, struct wl_resource *resource,
-                                              struct wl_resource *positioner, uint32_t token)
+static void zwl_xdg_popup_protocol_reposition(struct wl_client *client,
+                                              struct wl_resource *resource,
+                                              struct wl_resource *positioner,
+                                              uint32_t token)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -45,7 +50,8 @@ static const struct xdg_popup_interface zwl_xdg_popup_interface = {
     .reposition = zwl_xdg_popup_protocol_reposition,
 };
 
-struct zwl_xdg_popup *zwl_xdg_popup_create(struct wl_client *client, uint32_t id,
+struct zwl_xdg_popup *zwl_xdg_popup_create(struct wl_client *client,
+                                           uint32_t id,
                                            struct zwl_xdg_surface *xdg_surface)
 {
   UNUSED(xdg_surface);
@@ -64,7 +70,8 @@ struct zwl_xdg_popup *zwl_xdg_popup_create(struct wl_client *client, uint32_t id
     goto out_popup;
   }
 
-  wl_resource_set_implementation(resource, &zwl_xdg_popup_interface, popup, zwl_xdg_popup_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_xdg_popup_interface, popup,
+                                 zwl_xdg_popup_handle_destroy);
 
   return popup;
 

--- a/server/xdg_popup.h
+++ b/server/xdg_popup.h
@@ -10,7 +10,8 @@
 struct zwl_xdg_popup {};
 #pragma GCC diagnostic pop
 
-struct zwl_xdg_popup *zwl_xdg_popup_create(struct wl_client *client, uint32_t id,
+struct zwl_xdg_popup *zwl_xdg_popup_create(struct wl_client *client,
+                                           uint32_t id,
                                            struct zwl_xdg_surface *xdg_surface);
 
 #endif  //  WAYLAND_XDG_POPUP_H

--- a/server/xdg_positioner.c
+++ b/server/xdg_positioner.c
@@ -16,7 +16,8 @@ static void zwl_xdg_positioner_handle_destroy(struct wl_resource *resource)
   zwl_xdg_positioner_destroy(positioner);
 }
 
-static void zwl_xdg_positioner_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_positioner_protocol_destroy(struct wl_client *client,
+                                                struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
@@ -24,34 +25,38 @@ static void zwl_xdg_positioner_protocol_destroy(struct wl_client *client, struct
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-static void zwl_xdg_positioner_protocol_set_size(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_positioner_protocol_set_size(struct wl_client *client,
+                                                 struct wl_resource *resource,
                                                  int32_t width, int32_t height)
 {}
-static void zwl_xdg_positioner_protocol_set_anchor_rect(struct wl_client *client,
-                                                        struct wl_resource *resource, int32_t x, int32_t y,
-                                                        int32_t width, int32_t height)
+static void zwl_xdg_positioner_protocol_set_anchor_rect(
+    struct wl_client *client, struct wl_resource *resource, int32_t x,
+    int32_t y, int32_t width, int32_t height)
 {}
-static void zwl_xdg_positioner_protocol_set_anchor(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_positioner_protocol_set_anchor(struct wl_client *client,
+                                                   struct wl_resource *resource,
                                                    uint32_t anchor)
 {}
-static void zwl_xdg_positioner_protocol_set_gravity(struct wl_client *client, struct wl_resource *resource,
-                                                    uint32_t gravity)
+static void zwl_xdg_positioner_protocol_set_gravity(
+    struct wl_client *client, struct wl_resource *resource, uint32_t gravity)
 {}
-static void zwl_xdg_positioner_protocol_set_constraint_adjustment(struct wl_client *client,
-                                                                  struct wl_resource *resource,
-                                                                  uint32_t constraint_adjustment)
+static void zwl_xdg_positioner_protocol_set_constraint_adjustment(
+    struct wl_client *client, struct wl_resource *resource,
+    uint32_t constraint_adjustment)
 {}
-static void zwl_xdg_positioner_protocol_set_offset(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_positioner_protocol_set_offset(struct wl_client *client,
+                                                   struct wl_resource *resource,
                                                    int32_t x, int32_t y)
 {}
-static void zwl_xdg_positioner_protocol_set_reactive(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_positioner_protocol_set_reactive(
+    struct wl_client *client, struct wl_resource *resource)
 {}
-static void zwl_xdg_positioner_protocol_set_parent_size(struct wl_client *client,
-                                                        struct wl_resource *resource, int32_t parent_width,
-                                                        int32_t parent_height)
+static void zwl_xdg_positioner_protocol_set_parent_size(
+    struct wl_client *client, struct wl_resource *resource,
+    int32_t parent_width, int32_t parent_height)
 {}
-static void zwl_xdg_positioner_protocol_set_parent_configure(struct wl_client *client,
-                                                             struct wl_resource *resource, uint32_t serial)
+static void zwl_xdg_positioner_protocol_set_parent_configure(
+    struct wl_client *client, struct wl_resource *resource, uint32_t serial)
 {}
 #pragma GCC diagnostic pop
 
@@ -61,14 +66,16 @@ static const struct xdg_positioner_interface zwl_xdg_positioner_interface = {
     .set_anchor_rect = zwl_xdg_positioner_protocol_set_anchor_rect,
     .set_anchor = zwl_xdg_positioner_protocol_set_anchor,
     .set_gravity = zwl_xdg_positioner_protocol_set_gravity,
-    .set_constraint_adjustment = zwl_xdg_positioner_protocol_set_constraint_adjustment,
+    .set_constraint_adjustment =
+        zwl_xdg_positioner_protocol_set_constraint_adjustment,
     .set_offset = zwl_xdg_positioner_protocol_set_offset,
     .set_reactive = zwl_xdg_positioner_protocol_set_reactive,
     .set_parent_size = zwl_xdg_positioner_protocol_set_parent_size,
     .set_parent_configure = zwl_xdg_positioner_protocol_set_parent_configure,
 };
 
-struct zwl_xdg_positioner *zwl_xdg_positioner_create(struct wl_client *client, uint32_t id)
+struct zwl_xdg_positioner *zwl_xdg_positioner_create(struct wl_client *client,
+                                                     uint32_t id)
 {
   struct zwl_xdg_positioner *positioner;
   struct wl_resource *resource;
@@ -85,8 +92,8 @@ struct zwl_xdg_positioner *zwl_xdg_positioner_create(struct wl_client *client, u
     goto out_positioner;
   }
 
-  wl_resource_set_implementation(resource, &zwl_xdg_positioner_interface, positioner,
-                                 zwl_xdg_positioner_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_xdg_positioner_interface,
+                                 positioner, zwl_xdg_positioner_handle_destroy);
 
   return positioner;
 
@@ -97,4 +104,7 @@ out:
   return NULL;
 }
 
-static void zwl_xdg_positioner_destroy(struct zwl_xdg_positioner *positioner) { free(positioner); }
+static void zwl_xdg_positioner_destroy(struct zwl_xdg_positioner *positioner)
+{
+  free(positioner);
+}

--- a/server/xdg_positioner.h
+++ b/server/xdg_positioner.h
@@ -8,6 +8,7 @@
 struct zwl_xdg_positioner {};
 #pragma GCC diagnostic pop
 
-struct zwl_xdg_positioner *zwl_xdg_positioner_create(struct wl_client *client, uint32_t id);
+struct zwl_xdg_positioner *zwl_xdg_positioner_create(struct wl_client *client,
+                                                     uint32_t id);
 
 #endif  //  ZWAYLAND_XDG_POSITIONER_H

--- a/server/xdg_surface.c
+++ b/server/xdg_surface.c
@@ -21,13 +21,15 @@ static void zwl_xdg_surface_handle_destroy(struct wl_resource* resource)
   zwl_xdg_surface_destroy(xdg_surface);
 }
 
-static void zwl_xdg_surface_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
+static void zwl_xdg_surface_protocol_destroy(struct wl_client* client,
+                                             struct wl_resource* resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
 
-static void zwl_xdg_surface_protocol_get_toplevel(struct wl_client* client, struct wl_resource* resource,
+static void zwl_xdg_surface_protocol_get_toplevel(struct wl_client* client,
+                                                  struct wl_resource* resource,
                                                   uint32_t id)
 {
   struct zwl_xdg_surface* xdg_surface = wl_resource_get_user_data(resource);
@@ -39,8 +41,10 @@ static void zwl_xdg_surface_protocol_get_toplevel(struct wl_client* client, stru
   }
 }
 
-static void zwl_xdg_surface_protocol_get_popup(struct wl_client* client, struct wl_resource* resource,
-                                               uint32_t id, struct wl_resource* parent,
+static void zwl_xdg_surface_protocol_get_popup(struct wl_client* client,
+                                               struct wl_resource* resource,
+                                               uint32_t id,
+                                               struct wl_resource* parent,
                                                struct wl_resource* positioner)
 {
   UNUSED(parent);
@@ -54,9 +58,9 @@ static void zwl_xdg_surface_protocol_get_popup(struct wl_client* client, struct 
   }
 }
 
-static void zwl_xdg_surface_protocol_set_window_geometry(struct wl_client* client,
-                                                         struct wl_resource* resource, int32_t x, int32_t y,
-                                                         int32_t width, int32_t height)
+static void zwl_xdg_surface_protocol_set_window_geometry(
+    struct wl_client* client, struct wl_resource* resource, int32_t x,
+    int32_t y, int32_t width, int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -73,7 +77,8 @@ static void zwl_xdg_surface_protocol_set_window_geometry(struct wl_client* clien
   wl_signal_emit(&xdg_surface->set_window_geometry_signal, &window_geometry);
 }
 
-static void zwl_xdg_surface_protocol_ack_configure(struct wl_client* client, struct wl_resource* resource,
+static void zwl_xdg_surface_protocol_ack_configure(struct wl_client* client,
+                                                   struct wl_resource* resource,
                                                    uint32_t serial)
 {
   UNUSED(client);
@@ -90,14 +95,17 @@ static const struct xdg_surface_interface zwl_xdg_surface_interface = {
     .ack_configure = zwl_xdg_surface_protocol_ack_configure,
 };
 
-static void zwl_xdg_surface_surface_destroy_signal_handler(struct wl_listener* listener, void* data)
+static void zwl_xdg_surface_surface_destroy_signal_handler(
+    struct wl_listener* listener, void* data)
 {
   UNUSED(data);
-  struct zwl_xdg_surface* xdg_surface = wl_container_of(listener, xdg_surface, surface_destroy_listener);
+  struct zwl_xdg_surface* xdg_surface =
+      wl_container_of(listener, xdg_surface, surface_destroy_listener);
   wl_resource_destroy(xdg_surface->resource);
 }
 
-struct zwl_xdg_surface* zwl_xdg_surface_create(struct wl_client* client, uint32_t id,
+struct zwl_xdg_surface* zwl_xdg_surface_create(struct wl_client* client,
+                                               uint32_t id,
                                                struct zwl_surface* surface)
 {
   struct zwl_xdg_surface* xdg_surface;
@@ -115,14 +123,15 @@ struct zwl_xdg_surface* zwl_xdg_surface_create(struct wl_client* client, uint32_
     wl_client_post_no_memory(client);
     goto out_xdg_surface;
   }
-  wl_resource_set_implementation(resource, &zwl_xdg_surface_interface, xdg_surface,
-                                 zwl_xdg_surface_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_xdg_surface_interface,
+                                 xdg_surface, zwl_xdg_surface_handle_destroy);
 
   xdg_surface->resource = resource;
   wl_signal_init(&xdg_surface->destroy_signal);
 
   xdg_surface->surface = surface;
-  xdg_surface->surface_destroy_listener.notify = zwl_xdg_surface_surface_destroy_signal_handler;
+  xdg_surface->surface_destroy_listener.notify =
+      zwl_xdg_surface_surface_destroy_signal_handler;
   surface_destroy_signal = zwl_surface_get_destroy_signal(surface);
   wl_signal_add(surface_destroy_signal, &xdg_surface->surface_destroy_listener);
 
@@ -150,7 +159,8 @@ void zwl_xdg_surface_configure(struct zwl_xdg_surface* xdg_surface)
   uint32_t serial;
 
   serial = wl_display_next_serial(xdg_surface->surface->compositor->display);
-  wl_signal_emit(&xdg_surface->configure_signal, NULL);  // second args will be "serial", maybe
+  wl_signal_emit(&xdg_surface->configure_signal,
+                 NULL);  // second args will be "serial", maybe
 
   xdg_surface_send_configure(xdg_surface->resource, serial);
 }

--- a/server/xdg_surface.h
+++ b/server/xdg_surface.h
@@ -18,7 +18,8 @@ struct zwl_xdg_surface {
   struct wl_signal set_window_geometry_signal;
 };
 
-struct zwl_xdg_surface *zwl_xdg_surface_create(struct wl_client *client, uint32_t id,
+struct zwl_xdg_surface *zwl_xdg_surface_create(struct wl_client *client,
+                                               uint32_t id,
                                                struct zwl_surface *surface);
 
 void zwl_xdg_surface_configure(struct zwl_xdg_surface *xdg_surface);

--- a/server/xdg_toplevel.c
+++ b/server/xdg_toplevel.c
@@ -22,13 +22,15 @@ static void zwl_xdg_toplevel_handle_destroy(struct wl_resource *resource)
   zwl_xdg_toplevel_destroy(xdg_toplevel);
 }
 
-static void zwl_xdg_toplevel_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_toplevel_protocol_destroy(struct wl_client *client,
+                                              struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
 
-static void zwl_xdg_toplevel_protocol_set_parent(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_toplevel_protocol_set_parent(struct wl_client *client,
+                                                 struct wl_resource *resource,
                                                  struct wl_resource *parent)
 {
   UNUSED(client);
@@ -37,7 +39,8 @@ static void zwl_xdg_toplevel_protocol_set_parent(struct wl_client *client, struc
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_title(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_toplevel_protocol_set_title(struct wl_client *client,
+                                                struct wl_resource *resource,
                                                 const char *title)
 {
   UNUSED(client);
@@ -50,7 +53,8 @@ static void zwl_xdg_toplevel_protocol_set_title(struct wl_client *client, struct
   free(old);
 }
 
-static void zwl_xdg_toplevel_protocol_set_app_id(struct wl_client *client, struct wl_resource *resource,
+static void zwl_xdg_toplevel_protocol_set_app_id(struct wl_client *client,
+                                                 struct wl_resource *resource,
                                                  const char *app_id)
 {
   UNUSED(client);
@@ -59,9 +63,9 @@ static void zwl_xdg_toplevel_protocol_set_app_id(struct wl_client *client, struc
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_show_window_menu(struct wl_client *client, struct wl_resource *resource,
-                                                       struct wl_resource *seat, uint32_t serial, int32_t x,
-                                                       int32_t y)
+static void zwl_xdg_toplevel_protocol_show_window_menu(
+    struct wl_client *client, struct wl_resource *resource,
+    struct wl_resource *seat, uint32_t serial, int32_t x, int32_t y)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -72,8 +76,10 @@ static void zwl_xdg_toplevel_protocol_show_window_menu(struct wl_client *client,
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_move(struct wl_client *client, struct wl_resource *resource,
-                                           struct wl_resource *seat, uint32_t serial)
+static void zwl_xdg_toplevel_protocol_move(struct wl_client *client,
+                                           struct wl_resource *resource,
+                                           struct wl_resource *seat,
+                                           uint32_t serial)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -82,8 +88,10 @@ static void zwl_xdg_toplevel_protocol_move(struct wl_client *client, struct wl_r
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_resize(struct wl_client *client, struct wl_resource *resource,
-                                             struct wl_resource *seat, uint32_t serial, uint32_t edges)
+static void zwl_xdg_toplevel_protocol_resize(struct wl_client *client,
+                                             struct wl_resource *resource,
+                                             struct wl_resource *seat,
+                                             uint32_t serial, uint32_t edges)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -93,8 +101,10 @@ static void zwl_xdg_toplevel_protocol_resize(struct wl_client *client, struct wl
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_max_size(struct wl_client *client, struct wl_resource *resource,
-                                                   int32_t width, int32_t height)
+static void zwl_xdg_toplevel_protocol_set_max_size(struct wl_client *client,
+                                                   struct wl_resource *resource,
+                                                   int32_t width,
+                                                   int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -103,8 +113,10 @@ static void zwl_xdg_toplevel_protocol_set_max_size(struct wl_client *client, str
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_min_size(struct wl_client *client, struct wl_resource *resource,
-                                                   int32_t width, int32_t height)
+static void zwl_xdg_toplevel_protocol_set_min_size(struct wl_client *client,
+                                                   struct wl_resource *resource,
+                                                   int32_t width,
+                                                   int32_t height)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -113,22 +125,25 @@ static void zwl_xdg_toplevel_protocol_set_min_size(struct wl_client *client, str
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_maximized(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_toplevel_protocol_set_maximized(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_unset_maximized(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_toplevel_protocol_unset_maximized(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_fullscreen(struct wl_client *client, struct wl_resource *resource,
-                                                     struct wl_resource *output)
+static void zwl_xdg_toplevel_protocol_set_fullscreen(
+    struct wl_client *client, struct wl_resource *resource,
+    struct wl_resource *output)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -136,14 +151,16 @@ static void zwl_xdg_toplevel_protocol_set_fullscreen(struct wl_client *client, s
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_toplevel_protocol_unset_fullscreen(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
   // TODO: implement
 }
 
-static void zwl_xdg_toplevel_protocol_set_minimized(struct wl_client *client, struct wl_resource *resource)
+static void zwl_xdg_toplevel_protocol_set_minimized(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -167,7 +184,8 @@ static const struct xdg_toplevel_interface zwl_xdg_toplevel_interface = {
     .set_minimized = zwl_xdg_toplevel_protocol_set_minimized,
 };
 
-static void zwl_xdg_toplevel_xdg_surface_destroy_signal_handler(struct wl_listener *listener, void *data)
+static void zwl_xdg_toplevel_xdg_surface_destroy_signal_handler(
+    struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zwl_xdg_toplevel *xdg_toplevel =
@@ -175,7 +193,8 @@ static void zwl_xdg_toplevel_xdg_surface_destroy_signal_handler(struct wl_listen
   wl_resource_destroy(xdg_toplevel->resource);
 }
 
-static void zwl_xdg_toplevel_xdg_surface_configure_handler(struct wl_listener *listener, void *data)
+static void zwl_xdg_toplevel_xdg_surface_configure_handler(
+    struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zwl_xdg_toplevel *xdg_toplevel =
@@ -186,61 +205,73 @@ static void zwl_xdg_toplevel_xdg_surface_configure_handler(struct wl_listener *l
 
   // TODO: configure states if needed.
 
-  // TODO: send configure event after beeing notified that the cuboid window has actually resized
-  zsurface_toplevel_resize(xdg_toplevel->zsurface_toplevel, (float)xdg_toplevel->config.width / 10,
+  // TODO: send configure event after beeing notified that the cuboid window has
+  // actually resized
+  zsurface_toplevel_resize(xdg_toplevel->zsurface_toplevel,
+                           (float)xdg_toplevel->config.width / 10,
                            (float)xdg_toplevel->config.height / 10);
 
-  xdg_toplevel_send_configure(xdg_toplevel->resource, xdg_toplevel->config.width, xdg_toplevel->config.height,
-                              &states);
+  xdg_toplevel_send_configure(xdg_toplevel->resource,
+                              xdg_toplevel->config.width,
+                              xdg_toplevel->config.height, &states);
 
   wl_array_release(&states);
 
   xdg_toplevel->configured = true;
 }
 
-static void zwl_xdg_toplevel_xdg_surface_set_window_geometry_handler(struct wl_listener *listener, void *data)
+static void zwl_xdg_toplevel_xdg_surface_set_window_geometry_handler(
+    struct wl_listener *listener, void *data)
 {
   struct zwl_xdg_surface_window_geometry *window_geometry = data;
-  struct zwl_xdg_toplevel *xdg_toplevel =
-      wl_container_of(listener, xdg_toplevel, xdg_surface_set_window_geometry_listener);
+  struct zwl_xdg_toplevel *xdg_toplevel = wl_container_of(
+      listener, xdg_toplevel, xdg_surface_set_window_geometry_listener);
 
   xdg_toplevel->config.width = window_geometry->width;
   xdg_toplevel->config.height = window_geometry->height;
   xdg_toplevel->configured = false;
 }
 
-static void zwl_xdg_toplevel_surface_commit_handler(struct wl_listener *listener, void *data)
+static void zwl_xdg_toplevel_surface_commit_handler(
+    struct wl_listener *listener, void *data)
 {
   UNUSED(data);
-  struct zwl_xdg_toplevel *xdg_toplevel = wl_container_of(listener, xdg_toplevel, surface_commit_listener);
+  struct zwl_xdg_toplevel *xdg_toplevel =
+      wl_container_of(listener, xdg_toplevel, surface_commit_listener);
   struct zwl_surface *surface = xdg_toplevel->xdg_surface->surface;
 
   // TODO: apply other state if needed
 
-  if (xdg_toplevel->configured == false) zwl_xdg_surface_configure(xdg_toplevel->xdg_surface);
+  if (xdg_toplevel->configured == false)
+    zwl_xdg_surface_configure(xdg_toplevel->xdg_surface);
 
   // TODO: xdg_surface.configure should be scheduled, not immediate.
 
   // TODO: config state must be applied after the clinet replies ack_configure.
 
   if (surface->pending.buffer_resource != NULL) {
-    struct wl_shm_buffer *shm_buffer = wl_shm_buffer_get(surface->pending.buffer_resource);
+    struct wl_shm_buffer *shm_buffer =
+        wl_shm_buffer_get(surface->pending.buffer_resource);
     uint32_t width = wl_shm_buffer_get_width(shm_buffer);
     uint32_t height = wl_shm_buffer_get_height(shm_buffer);
 
-    struct zsurface_view *view = zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
+    struct zsurface_view *view =
+        zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
 
     wl_shm_buffer_begin_access(shm_buffer);
     struct zsurface_color_bgra *data = wl_shm_buffer_get_data(shm_buffer);
-    zsurface_view_set_texture(view, data, width, height);  // TODO: pass format info
+    zsurface_view_set_texture(view, data, width,
+                              height);  // TODO: pass format info
     zsurface_view_commit(view);
     wl_shm_buffer_end_access(shm_buffer);
   }
 
-  if (surface->pending.buffer_resource != NULL) wl_buffer_send_release(surface->pending.buffer_resource);
+  if (surface->pending.buffer_resource != NULL)
+    wl_buffer_send_release(surface->pending.buffer_resource);
 }
 
-static void zwl_xdg_toplevel_zsurface_view_callback_done(void *data, uint32_t callback_time)
+static void zwl_xdg_toplevel_zsurface_view_callback_done(void *data,
+                                                         uint32_t callback_time)
 {
   struct zwl_callback *callback = data;
 
@@ -248,17 +279,21 @@ static void zwl_xdg_toplevel_zsurface_view_callback_done(void *data, uint32_t ca
   wl_resource_destroy(callback->resource);
 }
 
-static void zwl_xdg_toplevel_surface_frame_handler(struct wl_listener *listener, void *data)
+static void zwl_xdg_toplevel_surface_frame_handler(struct wl_listener *listener,
+                                                   void *data)
 {
   struct zwl_callback *callback = data;
-  struct zwl_xdg_toplevel *xdg_toplevel = wl_container_of(listener, xdg_toplevel, surface_frame_listener);
-  struct zsurface_view *view = zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
+  struct zwl_xdg_toplevel *xdg_toplevel =
+      wl_container_of(listener, xdg_toplevel, surface_frame_listener);
+  struct zsurface_view *view =
+      zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
 
-  zsurface_view_add_frame_callback(view, zwl_xdg_toplevel_zsurface_view_callback_done, callback);
+  zsurface_view_add_frame_callback(
+      view, zwl_xdg_toplevel_zsurface_view_callback_done, callback);
 }
 
-struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint32_t id,
-                                                 struct zwl_xdg_surface *xdg_surface)
+struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(
+    struct wl_client *client, uint32_t id, struct zwl_xdg_surface *xdg_surface)
 {
   struct zwl_xdg_toplevel *xdg_toplevel;
   struct wl_resource *resource;
@@ -269,14 +304,16 @@ struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint3
     goto out;
   }
 
-  xdg_toplevel->zsurface_toplevel = zsurface_create_toplevel_view(xdg_surface->surface->compositor->zsurface);
+  xdg_toplevel->zsurface_toplevel =
+      zsurface_create_toplevel_view(xdg_surface->surface->compositor->zsurface);
   if (xdg_toplevel->zsurface_toplevel == NULL) {
     wl_client_post_no_memory(client);
     goto out_xdg_toplevel;
   }
 
   {
-    struct zsurface_view *view = zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
+    struct zsurface_view *view =
+        zsurface_toplevel_get_view(xdg_toplevel->zsurface_toplevel);
     zsurface_view_set_user_data(view, xdg_surface->surface);
   }
 
@@ -285,38 +322,47 @@ struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint3
     wl_client_post_no_memory(client);
     goto out_zsurface_toplevel;
   }
-  wl_resource_set_implementation(resource, &zwl_xdg_toplevel_interface, xdg_toplevel,
-                                 zwl_xdg_toplevel_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_xdg_toplevel_interface,
+                                 xdg_toplevel, zwl_xdg_toplevel_handle_destroy);
 
   xdg_toplevel->resource = resource;
 
   /* zalloc set xdg_toplevel->config to {0,0}*/
   xdg_toplevel->configured = false;
 
-  xdg_toplevel->xdg_surface_configure_listener.notify = zwl_xdg_toplevel_xdg_surface_configure_handler;
-  wl_signal_add(&xdg_surface->configure_signal, &xdg_toplevel->xdg_surface_configure_listener);
+  xdg_toplevel->xdg_surface_configure_listener.notify =
+      zwl_xdg_toplevel_xdg_surface_configure_handler;
+  wl_signal_add(&xdg_surface->configure_signal,
+                &xdg_toplevel->xdg_surface_configure_listener);
 
   xdg_toplevel->xdg_surface = xdg_surface;
-  xdg_toplevel->xdg_surface_destroy_listener.notify = zwl_xdg_toplevel_xdg_surface_destroy_signal_handler;
-  wl_signal_add(&xdg_surface->destroy_signal, &xdg_toplevel->xdg_surface_destroy_listener);
+  xdg_toplevel->xdg_surface_destroy_listener.notify =
+      zwl_xdg_toplevel_xdg_surface_destroy_signal_handler;
+  wl_signal_add(&xdg_surface->destroy_signal,
+                &xdg_toplevel->xdg_surface_destroy_listener);
 
   xdg_toplevel->xdg_surface_set_window_geometry_listener.notify =
       zwl_xdg_toplevel_xdg_surface_set_window_geometry_handler;
   wl_signal_add(&xdg_surface->set_window_geometry_signal,
                 &xdg_toplevel->xdg_surface_set_window_geometry_listener);
 
-  xdg_toplevel->surface_commit_listener.notify = zwl_xdg_toplevel_surface_commit_handler;
-  wl_signal_add(&xdg_surface->surface->commit_signal, &xdg_toplevel->surface_commit_listener);
+  xdg_toplevel->surface_commit_listener.notify =
+      zwl_xdg_toplevel_surface_commit_handler;
+  wl_signal_add(&xdg_surface->surface->commit_signal,
+                &xdg_toplevel->surface_commit_listener);
 
-  xdg_toplevel->surface_frame_listener.notify = zwl_xdg_toplevel_surface_frame_handler;
-  wl_signal_add(&xdg_surface->surface->frame_signal, &xdg_toplevel->surface_frame_listener);
+  xdg_toplevel->surface_frame_listener.notify =
+      zwl_xdg_toplevel_surface_frame_handler;
+  wl_signal_add(&xdg_surface->surface->frame_signal,
+                &xdg_toplevel->surface_frame_listener);
 
   xdg_toplevel->title = strdup("");
 
   return xdg_toplevel;
 
 out_zsurface_toplevel:
-  zsurface_destroy_toplevel_view(xdg_surface->surface->compositor->zsurface, xdg_toplevel->zsurface_toplevel);
+  zsurface_destroy_toplevel_view(xdg_surface->surface->compositor->zsurface,
+                                 xdg_toplevel->zsurface_toplevel);
 
 out_xdg_toplevel:
   free(xdg_toplevel);
@@ -332,8 +378,9 @@ static void zwl_xdg_toplevel_destroy(struct zwl_xdg_toplevel *xdg_toplevel)
   wl_list_remove(&xdg_toplevel->xdg_surface_configure_listener.link);
   wl_list_remove(&xdg_toplevel->xdg_surface_set_window_geometry_listener.link);
   wl_list_remove(&xdg_toplevel->xdg_surface_destroy_listener.link);
-  zsurface_destroy_toplevel_view(xdg_toplevel->xdg_surface->surface->compositor->zsurface,
-                                 xdg_toplevel->zsurface_toplevel);
+  zsurface_destroy_toplevel_view(
+      xdg_toplevel->xdg_surface->surface->compositor->zsurface,
+      xdg_toplevel->zsurface_toplevel);
   free(xdg_toplevel->title);
   free(xdg_toplevel);
 }

--- a/server/xdg_toplevel.h
+++ b/server/xdg_toplevel.h
@@ -26,7 +26,7 @@ struct zwl_xdg_toplevel {
   struct zsurface_toplevel *zsurface_toplevel;
 };
 
-struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(struct wl_client *client, uint32_t id,
-                                                 struct zwl_xdg_surface *xdg_surface);
+struct zwl_xdg_toplevel *zwl_xdg_toplevel_create(
+    struct wl_client *client, uint32_t id, struct zwl_xdg_surface *xdg_surface);
 
 #endif  //  ZWAYLAND_XDG_TOPLEVEL_H

--- a/server/xdg_wm_base.c
+++ b/server/xdg_wm_base.c
@@ -25,13 +25,15 @@ static void zwl_wm_base_handle_destroy(struct wl_resource *resource)
   zwl_wm_base_destroy(wm_base);
 }
 
-static void zwl_wm_base_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+static void zwl_wm_base_protocol_destroy(struct wl_client *client,
+                                         struct wl_resource *resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
 }
 
-static void zwl_wm_base_protocol_create_positioner(struct wl_client *client, struct wl_resource *resource,
+static void zwl_wm_base_protocol_create_positioner(struct wl_client *client,
+                                                   struct wl_resource *resource,
                                                    uint32_t id)
 {
   UNUSED(resource);
@@ -43,8 +45,9 @@ static void zwl_wm_base_protocol_create_positioner(struct wl_client *client, str
   }
 }
 
-static void zwl_wm_base_protocol_get_xdg_surface(struct wl_client *client, struct wl_resource *resource,
-                                                 uint32_t id, struct wl_resource *surface_resource)
+static void zwl_wm_base_protocol_get_xdg_surface(
+    struct wl_client *client, struct wl_resource *resource, uint32_t id,
+    struct wl_resource *surface_resource)
 {
   UNUSED(resource);
   struct zwl_xdg_surface *xdg_furface;
@@ -58,7 +61,9 @@ static void zwl_wm_base_protocol_get_xdg_surface(struct wl_client *client, struc
   }
 }
 
-static void zwl_wm_base_protocol_pong(struct wl_client *client, struct wl_resource *resource, uint32_t serial)
+static void zwl_wm_base_protocol_pong(struct wl_client *client,
+                                      struct wl_resource *resource,
+                                      uint32_t serial)
 {
   UNUSED(client);
   UNUSED(resource);
@@ -73,7 +78,8 @@ static const struct xdg_wm_base_interface zwl_wm_base_interface = {
     .pong = zwl_wm_base_protocol_pong,
 };
 
-struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client, uint32_t version, uint32_t id)
+struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client,
+                                       uint32_t version, uint32_t id)
 {
   UNUSED(version);
   struct zwl_wm_base *wm_base;
@@ -90,7 +96,8 @@ struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client, uint32_t versio
     wl_client_post_no_memory(client);
     goto out_wm_base;
   }
-  wl_resource_set_implementation(resource, &zwl_wm_base_interface, wm_base, zwl_wm_base_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_wm_base_interface, wm_base,
+                                 zwl_wm_base_handle_destroy);
 
   return wm_base;
 

--- a/server/xdg_wm_base.h
+++ b/server/xdg_wm_base.h
@@ -5,6 +5,7 @@
 
 struct zwl_wm_base;
 
-struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client, uint32_t version, uint32_t id);
+struct zwl_wm_base *zwl_wm_base_create(struct wl_client *client,
+                                       uint32_t version, uint32_t id);
 
 #endif  //  ZWAYLAND_XDG_WM_BASE

--- a/server/xdg_wm_base_global.c
+++ b/server/xdg_wm_base_global.c
@@ -12,7 +12,8 @@
 struct zwl_wm_base_global {};
 #pragma GCC diagnostic pop
 
-static void zwl_wm_base_global_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_wm_base_global_bind(struct wl_client *client, void *data,
+                                    uint32_t version, uint32_t id)
 {
   UNUSED(data);
   struct zwl_wm_base *wm_base;
@@ -31,7 +32,8 @@ struct zwl_wm_base_global *zwl_wm_base_global_create(struct wl_display *display)
   wm_base_global = zalloc(sizeof *wm_base_global);
   if (wm_base_global == NULL) goto out;
 
-  global = wl_global_create(display, &xdg_wm_base_interface, 3, wm_base_global, zwl_wm_base_global_bind);
+  global = wl_global_create(display, &xdg_wm_base_interface, 3, wm_base_global,
+                            zwl_wm_base_global_bind);
   if (global == NULL) goto out_wm_base;
 
   return wm_base_global;

--- a/server/xdg_wm_base_global.h
+++ b/server/xdg_wm_base_global.h
@@ -5,6 +5,7 @@
 
 struct zwl_wm_base_global;
 
-struct zwl_wm_base_global *zwl_wm_base_global_create(struct wl_display *display);
+struct zwl_wm_base_global *zwl_wm_base_global_create(
+    struct wl_display *display);
 
 #endif  //  ZWAYLAND_XDG_WM_BASE_GLOBAL_H

--- a/server/zxdg_output.c
+++ b/server/zxdg_output.c
@@ -16,7 +16,8 @@ static void zwl_zxdg_output_handle_destroy(struct wl_resource* resource)
   zwl_zxdg_output_destroy(zxdg_output);
 }
 
-static void zwl_zxdg_output_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
+static void zwl_zxdg_output_protocol_destroy(struct wl_client* client,
+                                             struct wl_resource* resource)
 {
   UNUSED(client);
   wl_resource_destroy(resource);
@@ -26,7 +27,8 @@ static const struct zxdg_output_v1_interface zwl_zxdg_output_interface = {
     .destroy = zwl_zxdg_output_protocol_destroy,
 };
 
-struct zwl_zxdg_output* zwl_zxdg_output_create(struct wl_client* client, uint32_t id)
+struct zwl_zxdg_output* zwl_zxdg_output_create(struct wl_client* client,
+                                               uint32_t id)
 {
   struct zwl_zxdg_output* zxdg_output;
   struct wl_resource* resource;
@@ -43,8 +45,8 @@ struct zwl_zxdg_output* zwl_zxdg_output_create(struct wl_client* client, uint32_
     goto out_zxdg_output;
   }
 
-  wl_resource_set_implementation(resource, &zwl_zxdg_output_interface, zxdg_output,
-                                 zwl_zxdg_output_handle_destroy);
+  wl_resource_set_implementation(resource, &zwl_zxdg_output_interface,
+                                 zxdg_output, zwl_zxdg_output_handle_destroy);
 
   zxdg_output->resource = resource;
 
@@ -57,4 +59,7 @@ out:
   return NULL;
 }
 
-static void zwl_zxdg_output_destroy(struct zwl_zxdg_output* zxdg_output) { free(zxdg_output); }
+static void zwl_zxdg_output_destroy(struct zwl_zxdg_output* zxdg_output)
+{
+  free(zxdg_output);
+}

--- a/server/zxdg_output.h
+++ b/server/zxdg_output.h
@@ -7,6 +7,7 @@ struct zwl_zxdg_output {
   struct wl_resource* resource;
 };
 
-struct zwl_zxdg_output* zwl_zxdg_output_create(struct wl_client* client, uint32_t id);
+struct zwl_zxdg_output* zwl_zxdg_output_create(struct wl_client* client,
+                                               uint32_t id);
 
 #endif  //  ZWAYLAND_ZXDG_OUTPUT_H

--- a/server/zxdg_output_manager.c
+++ b/server/zxdg_output_manager.c
@@ -6,16 +6,17 @@
 #include "util.h"
 #include "zxdg_output.h"
 
-static void zwl_zxdg_output_manager_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+static void zwl_zxdg_output_manager_protocol_destroy(
+    struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
   UNUSED(resource);
   // nothing to do
 }
 
-static void zwl_zxdg_output_manager_protocol_get_xdg_output(struct wl_client *client,
-                                                            struct wl_resource *resource, uint32_t id,
-                                                            struct wl_resource *output)
+static void zwl_zxdg_output_manager_protocol_get_xdg_output(
+    struct wl_client *client, struct wl_resource *resource, uint32_t id,
+    struct wl_resource *output)
 {
   UNUSED(resource);
   UNUSED(output);
@@ -31,26 +32,31 @@ static void zwl_zxdg_output_manager_protocol_get_xdg_output(struct wl_client *cl
   zxdg_output_v1_send_done(zxdg_output->resource);
 }
 
-static const struct zxdg_output_manager_v1_interface zwl_output_manager_interface = {
-    .destroy = zwl_zxdg_output_manager_protocol_destroy,
-    .get_xdg_output = zwl_zxdg_output_manager_protocol_get_xdg_output,
+static const struct zxdg_output_manager_v1_interface
+    zwl_output_manager_interface = {
+        .destroy = zwl_zxdg_output_manager_protocol_destroy,
+        .get_xdg_output = zwl_zxdg_output_manager_protocol_get_xdg_output,
 };
 
-static void zwl_zxdg_output_manager_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
+static void zwl_zxdg_output_manager_bind(struct wl_client *client, void *data,
+                                         uint32_t version, uint32_t id)
 {
   struct zwl_zxdg_output_manager *output_manager = data;
   struct wl_resource *resource;
 
-  resource = wl_resource_create(client, &zxdg_output_manager_v1_interface, version, id);
+  resource = wl_resource_create(client, &zxdg_output_manager_v1_interface,
+                                version, id);
   if (resource == NULL) {
     wl_client_post_no_memory(client);
     return;
   }
 
-  wl_resource_set_implementation(resource, &zwl_output_manager_interface, output_manager, NULL);
+  wl_resource_set_implementation(resource, &zwl_output_manager_interface,
+                                 output_manager, NULL);
 }
 
-struct zwl_zxdg_output_manager *zwl_zxdg_output_manager_create(struct wl_display *display)
+struct zwl_zxdg_output_manager *zwl_zxdg_output_manager_create(
+    struct wl_display *display)
 {
   struct zwl_zxdg_output_manager *output_manager;
   struct wl_global *global;
@@ -58,8 +64,8 @@ struct zwl_zxdg_output_manager *zwl_zxdg_output_manager_create(struct wl_display
   output_manager = zalloc(sizeof *output_manager);
   if (output_manager == NULL) goto out;
 
-  global = wl_global_create(display, &zxdg_output_manager_v1_interface, 3, output_manager,
-                            zwl_zxdg_output_manager_bind);
+  global = wl_global_create(display, &zxdg_output_manager_v1_interface, 3,
+                            output_manager, zwl_zxdg_output_manager_bind);
   if (global == NULL) goto out_output_manager;
 
   return output_manager;

--- a/server/zxdg_output_manager.h
+++ b/server/zxdg_output_manager.h
@@ -8,6 +8,7 @@
 struct zwl_zxdg_output_manager {};
 #pragma GCC diagnostic pop
 
-struct zwl_zxdg_output_manager *zwl_zxdg_output_manager_create(struct wl_display *display);
+struct zwl_zxdg_output_manager *zwl_zxdg_output_manager_create(
+    struct wl_display *display);
 
 #endif  //  ZWAYLAND_ZXDG_OUTPUT_MANAGER_H


### PR DESCRIPTION
clang formatterの行あたりの文字数の設定を110から80に変えました。
レビュー不要です。build通ったらマージします。
```
find . -regex '.*\.\(h\|cc\|c\)' -exec clang-format -style=file -i {} \;
```